### PR TITLE
Adding suppport for sanitizing query parameters.

### DIFF
--- a/lib/raven/backports/uri.rb
+++ b/lib/raven/backports/uri.rb
@@ -1,0 +1,104 @@
+# :stopdoc:
+
+# Stolen from ruby core's uri/common.rb, with modifications to support 1.8.x
+#
+# https://github.com/ruby/ruby/blob/trunk/lib/uri/common.rb
+#
+#
+
+module URI
+  TBLENCWWWCOMP_ = {} # :nodoc:
+  256.times do |i|
+    TBLENCWWWCOMP_[i.chr] = '%%%02X' % i
+  end
+  TBLENCWWWCOMP_[' '] = '+'
+  TBLENCWWWCOMP_.freeze
+  TBLDECWWWCOMP_ = {} # :nodoc:
+  256.times do |i|
+    h, l = i>>4, i&15
+    TBLDECWWWCOMP_['%%%X%X' % [h, l]] = i.chr
+    TBLDECWWWCOMP_['%%%x%X' % [h, l]] = i.chr
+    TBLDECWWWCOMP_['%%%X%x' % [h, l]] = i.chr
+    TBLDECWWWCOMP_['%%%x%x' % [h, l]] = i.chr
+  end
+  TBLDECWWWCOMP_['+'] = ' '
+  TBLDECWWWCOMP_.freeze
+
+  # Encode given +s+ to URL-encoded form data.
+  #
+  # This method doesn't convert *, -, ., 0-9, A-Z, _, a-z, but does convert SP
+  # (ASCII space) to + and converts others to %XX.
+  #
+  # This is an implementation of
+  # http://www.w3.org/TR/html5/forms.html#url-encoded-form-data
+  #
+  # See URI.decode_www_form_component, URI.encode_www_form
+  def self.encode_www_form_component(s)
+    str = s.to_s
+    if RUBY_VERSION < "1.9" && $KCODE =~ /u/i
+      str.gsub(/([^ a-zA-Z0-9_.-]+)/) do
+        '%' + $1.unpack('H2' * Rack::Utils.bytesize($1)).join('%').upcase
+      end.tr(' ', '+')
+    else
+      str.gsub(/[^*\-.0-9A-Z_a-z]/) {|m| TBLENCWWWCOMP_[m]}
+    end
+  end
+
+  # Decode given +str+ of URL-encoded form data.
+  #
+  # This decodes + to SP.
+  #
+  # See URI.encode_www_form_component, URI.decode_www_form
+  def self.decode_www_form_component(str, enc=nil)
+    raise ArgumentError, "invalid %-encoding (#{str})" unless /\A(?:%[0-9a-fA-F]{2}|[^%])*\z/ =~ str
+    str.gsub(/\+|%[0-9a-fA-F]{2}/) {|m| TBLDECWWWCOMP_[m]}
+  end
+
+  # Generate URL-encoded form data from given +enum+.
+  #
+  # This generates application/x-www-form-urlencoded data defined in HTML5
+  # from given an Enumerable object.
+  #
+  # This internally uses URI.encode_www_form_component(str).
+  #
+  # This method doesn't convert the encoding of given items, so convert them
+  # before call this method if you want to send data as other than original
+  # encoding or mixed encoding data. (Strings which are encoded in an HTML5
+  # ASCII incompatible encoding are converted to UTF-8.)
+  #
+  # This method doesn't handle files.  When you send a file, use
+  # multipart/form-data.
+  #
+  # This is an implementation of
+  # http://www.w3.org/TR/html5/forms.html#url-encoded-form-data
+  #
+  #    URI.encode_www_form([["q", "ruby"], ["lang", "en"]])
+  #    #=> "q=ruby&lang=en"
+  #    URI.encode_www_form("q" => "ruby", "lang" => "en")
+  #    #=> "q=ruby&lang=en"
+  #    URI.encode_www_form("q" => ["ruby", "perl"], "lang" => "en")
+  #    #=> "q=ruby&q=perl&lang=en"
+  #    URI.encode_www_form([["q", "ruby"], ["q", "perl"], ["lang", "en"]])
+  #    #=> "q=ruby&q=perl&lang=en"
+  #
+  # See URI.encode_www_form_component, URI.decode_www_form
+  def self.encode_www_form(enum)
+    enum.map do |k,v|
+      if v.nil?
+        encode_www_form_component(k)
+      elsif v.respond_to?(:to_ary)
+        v.to_ary.map do |w|
+          str = encode_www_form_component(k)
+          unless w.nil?
+            str << '='
+            str << encode_www_form_component(w)
+          end
+        end.join('&')
+      else
+        str = encode_www_form_component(k)
+        str << '='
+        str << encode_www_form_component(v)
+      end
+    end.join('&')
+  end
+end

--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -14,6 +14,11 @@ require 'raven/processor/sanitizedata'
 require 'raven/processor/removecircularreferences'
 require 'raven/processor/utf8conversion'
 
+major, minor, patch = RUBY_VERSION.split('.').map(&:to_i)
+if (major == 1 && minor < 9) || (major == 1 && minor == 9 && patch < 2)
+  require 'raven/backports/uri'
+end
+
 module Raven
   class << self
     # The client object is responsible for delivering formatted data to the Sentry server.

--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -14,6 +14,8 @@ module Raven
         process(v)
       elsif v.is_a?(Array)
         v.map{|a| sanitize(nil, a)}
+      elsif k == 'query_string'
+        sanitize_query_string(v)
       elsif v.is_a?(String) && (json = parse_json_or_nil(v))
         #if this string is actually a json obj, convert and sanitize
         json.is_a?(Hash) ? process(json).to_json : v
@@ -27,6 +29,13 @@ module Raven
     end
 
     private
+
+    def sanitize_query_string(query_string)
+      query_string.split('&').map do |key_val_pairs|
+        key, val = key_val_pairs.split('=')
+        "#{key}=#{sanitize(key, val)}"
+      end.join('&')
+    end
 
     def fields_re
       @fields_re ||= /(#{(DEFAULT_FIELDS + @sanitize_fields).join("|")})/i

--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -13,7 +13,7 @@ module Raven
       if v.is_a?(Hash)
         process(v)
       elsif v.is_a?(Array)
-        v.map{|a| sanitize(nil, a)}
+        v.map{|a| sanitize(k, a)}
       elsif k == 'query_string'
         sanitize_query_string(v)
       elsif v.is_a?(String) && (json = parse_json_or_nil(v))
@@ -31,10 +31,9 @@ module Raven
     private
 
     def sanitize_query_string(query_string)
-      query_string.split('&').map do |key_val_pairs|
-        key, val = key_val_pairs.split('=')
-        "#{key}=#{sanitize(key, val)}"
-      end.join('&')
+      query_hash = CGI::parse(query_string)
+      processed_query_hash = process(query_hash)
+      URI.encode_www_form(processed_query_hash)
     end
 
     def fields_re

--- a/spec/raven/processors/sanitizedata_processor_spec.rb
+++ b/spec/raven/processors/sanitizedata_processor_spec.rb
@@ -112,7 +112,7 @@ describe Raven::Processor::SanitizeData do
     data = {
       'sentry.interfaces.Http' => {
         'data' => {
-          'query_string' => 'foo=bar&password=barfoo'
+          'query_string' => 'foo=bar&password=secret'
         }
       }
     }
@@ -120,6 +120,6 @@ describe Raven::Processor::SanitizeData do
     result = @processor.process(data)
 
     vars = result["sentry.interfaces.Http"]["data"]
-    expect(vars["query_string"]).to eq("foo=bar&password=#{Raven::Processor::SanitizeData::STRING_MASK}")
+    expect(vars["query_string"]).to_not include("secret")
   end
 end

--- a/spec/raven/processors/sanitizedata_processor_spec.rb
+++ b/spec/raven/processors/sanitizedata_processor_spec.rb
@@ -108,18 +108,58 @@ describe Raven::Processor::SanitizeData do
     expect(result["array"][0]['password']).to eq(Raven::Processor::SanitizeData::STRING_MASK)
   end
 
-  it 'sanitizes query strings' do
-    data = {
-      'sentry.interfaces.Http' => {
-        'data' => {
-          'query_string' => 'foo=bar&password=secret'
+  context "query strings" do
+    it 'sanitizes' do
+      data = {
+        'sentry.interfaces.Http' => {
+          'data' => {
+            'query_string' => 'foo=bar&password=secret'
+          }
         }
       }
-    }
 
-    result = @processor.process(data)
+      result = @processor.process(data)
 
-    vars = result["sentry.interfaces.Http"]["data"]
-    expect(vars["query_string"]).to_not include("secret")
+      vars = result["sentry.interfaces.Http"]["data"]
+      expect(vars["query_string"]).to_not include("secret")
+    end
+
+    it 'handles multiple values for a key' do
+      data = {
+        'sentry.interfaces.Http' => {
+          'data' => {
+            'query_string' => 'foo=bar&foo=fubar&foo=barfoo'
+          }
+        }
+      }
+
+      result = @processor.process(data)
+
+      vars = result["sentry.interfaces.Http"]["data"]
+      query_string = vars["query_string"].split('&')
+      expect(query_string).to include("foo=bar")
+      expect(query_string).to include("foo=fubar")
+      expect(query_string).to include("foo=barfoo")
+    end
+
+    it 'handles url encoded keys and values' do
+      encoded_query_string = 'Bio+4%24=cA%24%7C-%7C+M%28%29n3%5E'
+      data = {
+        'sentry.interfaces.Http' => {
+          'data' => {
+            'query_string' => encoded_query_string
+          }
+        }
+      }
+
+      result = @processor.process(data)
+
+      vars = result["sentry.interfaces.Http"]["data"]
+      expect(vars["query_string"]).to eq(encoded_query_string)
+    end
+
+    it 'handles url encoded values' do
+
+    end
   end
 end

--- a/spec/raven/processors/sanitizedata_processor_spec.rb
+++ b/spec/raven/processors/sanitizedata_processor_spec.rb
@@ -107,4 +107,19 @@ describe Raven::Processor::SanitizeData do
 
     expect(result["array"][0]['password']).to eq(Raven::Processor::SanitizeData::STRING_MASK)
   end
+
+  it 'sanitizes query strings' do
+    data = {
+      'sentry.interfaces.Http' => {
+        'data' => {
+          'query_string' => 'foo=bar&password=barfoo'
+        }
+      }
+    }
+
+    result = @processor.process(data)
+
+    vars = result["sentry.interfaces.Http"]["data"]
+    expect(vars["query_string"]).to eq("foo=bar&password=#{Raven::Processor::SanitizeData::STRING_MASK}")
+  end
 end


### PR DESCRIPTION
Paired with @kjperry

For GET requests and POST requests with query parameters the query_string remains unsanitized. While GET requests with sensitive data is rare for our application we wanted to be sure that bad requests would be sanitized as expected.

![screen shot 2015-01-05 at 9 21 25 am](https://cloud.githubusercontent.com/assets/141914/5618203/17e26bca-94dc-11e4-83cf-f2778c1be1fe.png)
