### PR TITLE
Truncate project_root prefix from filename

### DIFF
--- a/lib/raven/interfaces/stack_trace.rb
+++ b/lib/raven/interfaces/stack_trace.rb
@@ -36,6 +36,12 @@ module Raven
         return nil if self.abs_path.nil?
 
         prefix = $LOAD_PATH.select { |s| self.abs_path.start_with?(s.to_s) }.sort_by { |s| s.to_s.length }.last
+        if prefix.nil? && Raven.configuration.project_root
+          project_root = Raven.configuration.project_root.to_s
+          if self.abs_path.start_with?(project_root)
+            prefix = project_root
+          end
+        end
         prefix ? self.abs_path[prefix.to_s.chomp(File::SEPARATOR).length+1..-1] : self.abs_path
       end
 

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -401,11 +401,11 @@ describe Raven::Event do
             expect(frames[1][:in_app]).to eq(false)
             expect(frames[2][:filename]).to eq("/gem/lib/path")
             expect(frames[2][:in_app]).to eq(false)
-            expect(frames[3][:filename]).to eq("/rails/root/app/foobar")
+            expect(frames[3][:filename]).to eq("app/foobar")
             expect(frames[3][:in_app]).to eq(true)
             expect(frames[4][:filename]).to eq("vendor/bundle/some_gem.rb")
             expect(frames[4][:in_app]).to eq(false)
-            expect(frames[5][:filename]).to eq("/rails/root/vendor/bundle/cache/other_gem.rb")
+            expect(frames[5][:filename]).to eq("vendor/bundle/cache/other_gem.rb")
             expect(frames[5][:in_app]).to eq(false)
           end
         end


### PR DESCRIPTION
Especially in Rails project, when an exception is raised in view template, the filename is always full path.
With capistrano (de-facto standard for Ruby application deployment), the full path differs on each release.
It causes Sentry to recognize the same error differently.