### PR TITLE
fix argument name missmatch

### DIFF
--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -22,7 +22,7 @@ module Raven
   # Use a standard Raven.configure call to configure your server credentials.
   class Rack
 
-    def self.capture_type(message, env, options = {})
+    def self.capture_type(exception, env, options = {})
       if env['requested_at']
         options[:time_spent] = Time.now - env['requested_at']
       end


### PR DESCRIPTION
Related to issue: https://github.com/getsentry/raven-ruby/issues/289.