### PR TITLE
Always preserve filename paths under project_root

### DIFF
--- a/lib/raven/interfaces/stack_trace.rb
+++ b/lib/raven/interfaces/stack_trace.rb
@@ -35,14 +35,17 @@ module Raven
       def filename
         return nil if self.abs_path.nil?
 
-        prefix = $LOAD_PATH.select { |s| self.abs_path.start_with?(s.to_s) }.sort_by { |s| s.to_s.length }.last
-        if prefix.nil? && Raven.configuration.project_root
-          project_root = Raven.configuration.project_root.to_s
-          if self.abs_path.start_with?(project_root)
-            prefix = project_root
-          end
+        prefix = if project_root && self.abs_path.start_with?(project_root)
+          project_root
+        else
+          $LOAD_PATH.select { |s| self.abs_path.start_with?(s.to_s) }.sort_by { |s| s.to_s.length }.last
         end
+
         prefix ? self.abs_path[prefix.to_s.chomp(File::SEPARATOR).length+1..-1] : self.abs_path
+      end
+
+      def project_root
+        @project_root ||= Raven.configuration.project_root && Raven.configuration.project_root.to_s
       end
 
       def to_hash(*args)


### PR DESCRIPTION
This addresses the second point from #288.

When a stack trace frame is from a path inside the project, the filename should be normalized relative to the project root. Only paths outside the project should be normalized based on `$LOAD_PATH`.

/cc @dannyfallon @nateberkopec 