### PR TITLE
Proposed: a new interface for sanitize_fields config

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -116,7 +116,7 @@ module Raven
       self.tags = {}
       self.async = false
       self.catch_debugged_exceptions = true
-      self.sanitize_fields = []
+      self.sanitize_fields = Raven::Processor::SanitizeData::DEFAULT_FIELDS
     end
 
     def server=(value)

--- a/lib/raven/processor.rb
+++ b/lib/raven/processor.rb
@@ -2,11 +2,8 @@ require 'json'
 
 module Raven
   class Processor
-    attr_accessor :sanitize_fields
-
     def initialize(client)
       @client = client
-      @sanitize_fields = client.configuration.sanitize_fields
     end
 
     def process(data)
@@ -22,6 +19,5 @@ module Raven
         nil
       end
     end
-
   end
 end

--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -5,6 +5,13 @@ module Raven
     DEFAULT_FIELDS = %w(authorization password passwd secret ssn social(.*)?sec)
     CREDIT_CARD_RE = /^(?:\d[ -]*?){13,16}$/
 
+    attr_accessor :sanitize_fields
+
+    def initialize(client)
+      super
+      self.sanitize_fields = client.configuration.sanitize_fields
+    end
+
     def process(value)
       value.inject(value) { |memo,(k,v)|  memo[k] = sanitize(k,v); memo }
     end
@@ -37,7 +44,7 @@ module Raven
     end
 
     def fields_re
-      @fields_re ||= /(#{(DEFAULT_FIELDS + @sanitize_fields).join("|")})/i
+      @fields_re ||= /(#{(sanitize_fields).join("|")})/i
     end
   end
 end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -51,7 +51,7 @@ describe Raven::Configuration do
     end
 
     it 'should have no sanitize fields' do
-      expect(subject[:sanitize_fields]).to eq([])
+      expect(subject[:sanitize_fields]).to eq(Raven::Processor::SanitizeData::DEFAULT_FIELDS)
     end
   end
 

--- a/spec/raven/processors/removecirculareferences_spec.rb
+++ b/spec/raven/processors/removecirculareferences_spec.rb
@@ -5,7 +5,6 @@ require 'spec_helper'
 describe Raven::Processor::RemoveCircularReferences do
   before do
     @client = double("client")
-    allow(@client).to receive_message_chain(:configuration, :sanitize_fields) { [] }
     @processor = Raven::Processor::RemoveCircularReferences.new(@client)
   end
 

--- a/spec/raven/processors/removestacktrace_spec.rb
+++ b/spec/raven/processors/removestacktrace_spec.rb
@@ -4,7 +4,6 @@ require 'raven/processor/removestacktrace'
 describe Raven::Processor::RemoveStacktrace do
   before do
     @client = double("client")
-    allow(@client).to receive_message_chain(:configuration, :sanitize_fields) { [] }
     @processor = Raven::Processor::RemoveStacktrace.new(@client)
   end
 

--- a/spec/raven/processors/utf8conversion_spec.rb
+++ b/spec/raven/processors/utf8conversion_spec.rb
@@ -5,7 +5,6 @@ require 'spec_helper'
 describe Raven::Processor::UTF8Conversion do
   before do
     @client = double("client")
-    allow(@client).to receive_message_chain(:configuration, :sanitize_fields) { [] }
     @processor = Raven::Processor::UTF8Conversion.new(@client)
   end
 


### PR DESCRIPTION
Old busted:
```ruby
Raven.configure do |config|
  config.sanitize_fields = %w(host User-Agent)
end
# We'll sanitize the defaults (password, ssn, etc), PLUS host and User-agent
```

New hotness:
```ruby
Raven.configure do |config|
  config.sanitize_fields = %w(host User-Agent)
end
# We sanitize ONLY host and User-Agent. If you want the old behavior, you must...
Raven.configure do |config|
  config.sanitize_fields << %w(host User-Agent)
end
```

After writing this all out, it's obvious that such a change should have some kind of deprecation cycle, otherwise we'd have a bunch of people not sanitizing things they thought they were! 

Also, after writing this change out, I'm not sure what the benefit is, since most of the default fields are "sanitized" anyway by the upstream Sentry server. It seems like an area where we should take convention over configuration. Or at least, the interface should make it a lot more difficult to *not* sanitize fields like "password" and "ssn". This change, I think, introduces *too much* configurability.