### PR TITLE
More detailed status report upon configuration

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -49,9 +49,15 @@ module Raven
     end
 
     # Tell the log that the client is good to go
-    def report_ready
-      logger.info "Raven #{VERSION} ready to catch errors"
+    def report_status
+      return if client.configuration.silence_ready
+      if client.configuration.send_in_current_environment?
+        logger.info "Raven #{VERSION} ready to catch errors"
+      else
+        logger.info "Raven #{VERSION} configured not to send errors."
+      end
     end
+    alias_method :report_ready, :report_status
 
     # Call this method to modify defaults in your initializers.
     #
@@ -63,7 +69,7 @@ module Raven
       yield(configuration) if block_given?
 
       self.client = Client.new(configuration)
-      report_ready unless client.configuration.silence_ready
+      report_status
       self.client
     end
 

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -100,6 +100,35 @@ describe Raven do
     end
   end
 
+  describe '.report_status' do
+    let(:ready_message) do
+      "Raven #{Raven::VERSION} ready to catch errors"
+    end
 
+    let(:not_ready_message) do
+      "Raven #{Raven::VERSION} configured not to send errors."
+    end
 
+    it 'logs a ready message when configured' do
+      Raven.configuration.silence_ready = false
+      expect(Raven.configuration).to(
+        receive(:send_in_current_environment?).and_return(true))
+      expect(Raven.logger).to receive(:info).with(ready_message)
+      Raven.report_status
+    end
+
+    it 'logs not ready message if the config does not send in current environment' do
+      Raven.configuration.silence_ready = false
+      expect(Raven.configuration).to(
+        receive(:send_in_current_environment?).and_return(false))
+      expect(Raven.logger).to receive(:info).with(not_ready_message)
+      Raven.report_status
+    end
+
+    it 'logs nothing if "silence_ready" configuration is true' do
+      Raven.configuration.silence_ready = true
+      expect(Raven.logger).not_to receive(:info)
+      Raven.report_status
+    end
+  end
 end


### PR DESCRIPTION
I was getting thrown off by the "ready to catch errors" message that was popping up even in environments where it was configured not to send.  My use case is that I have a Raven.configure block in my code all the time, but whether or not I actually enable capture is controlled the presence/absence of the SENTRY_DSN env var.  Since calling Raven.capture triggers the message, it came up every time regardless of whether I was actually capturing errors.

(I know this is a somewhat superficial PR, sorry!)

Two points open for debate (besides whether or not this PR is desired/worthwhile at all) are the actual text used to indicate that errors will not be sent, and whether or not to alias report_status with report_ready, for backwards compatibility purposes.  Technically report_ready is part of the public API, so even tho its doubtful that anyone was using it directly, better safe than sorry I suppose.  Another option is just leaving it named report_ready, but that seems marginally less correct.

Cheers!