### PR TITLE
Add support for sending release version

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -71,6 +71,8 @@ module Raven
 
     attr_accessor :server_name
 
+    attr_accessor :release
+
     # DEPRECATED: This option is now ignored as we use our own adapter.
     attr_accessor :json_adapter
 

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -24,7 +24,7 @@ module Raven
 
     attr_reader :id
     attr_accessor :project, :message, :timestamp, :time_spent, :level, :logger,
-      :culprit, :server_name, :modules, :extra, :tags, :context, :configuration
+      :culprit, :server_name, :release, :modules, :extra, :tags, :context, :configuration
 
     def initialize(init = {})
       @configuration = Raven.configuration
@@ -38,6 +38,7 @@ module Raven
       @logger        = 'root'
       @culprit       = nil
       @server_name   = @configuration.server_name || get_hostname
+      @release       = @configuration.release
       @modules       = get_modules if @configuration.send_modules
       @user          = {}
       @extra         = {}
@@ -103,6 +104,7 @@ module Raven
       }
       data[:culprit] = @culprit if @culprit
       data[:server_name] = @server_name if @server_name
+      data[:release] = @release if @release
       data[:modules] = @modules if @modules
       data[:extra] = @extra if @extra
       data[:tags] = @tags if @tags

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -18,6 +18,7 @@ describe Raven::Event do
           'my_custom_variable' => 'value'
         },
         :server_name => 'foo.local',
+        :release => '721e41770371db95eee98ca2707686226b993eda',
       }).to_hash
     end
 
@@ -35,6 +36,10 @@ describe Raven::Event do
 
     it 'has server name' do
       expect(hash[:server_name]).to eq('foo.local')
+    end
+
+    it 'has release' do
+      expect(hash[:release]).to eq('721e41770371db95eee98ca2707686226b993eda')
     end
 
     it 'has tag data' do


### PR DESCRIPTION
http://sentry.readthedocs.org/en/latest/developer/client/#release

The [Python](https://github.com/getsentry/raven-python/commit/332e05a8621cb170985ef2feb855810e022b2ac8) and [Go](https://github.com/getsentry/raven-go/commit/82e450d4d524d18d05dc3a90ecd8055f349d3dd2) clients can already send this parameter, so I thought I'd add it to the Ruby client too. As I understand it, `release` is basically just a tag for now, but will tie into https://github.com/getsentry/sentry/issues/1187 later (@dcramer, am I right about this?).