### PR TITLE
Use load path to normalize vendored gem filenames

### DIFF
--- a/lib/raven/interfaces/stack_trace.rb
+++ b/lib/raven/interfaces/stack_trace.rb
@@ -36,17 +36,27 @@ module Raven
       def filename
         return nil if self.abs_path.nil?
 
-        prefix = if project_root && self.abs_path.start_with?(project_root)
+        prefix = if under_project_root? && in_app
           project_root
+        elsif under_project_root?
+          longest_load_path || project_root
         else
-          $LOAD_PATH.select { |s| self.abs_path.start_with?(s.to_s) }.sort_by { |s| s.to_s.length }.last
+          longest_load_path
         end
 
         prefix ? self.abs_path[prefix.to_s.chomp(File::SEPARATOR).length+1..-1] : self.abs_path
       end
 
+      def under_project_root?
+        project_root && abs_path.start_with?(project_root)
+      end
+
       def project_root
         @project_root ||= Raven.configuration.project_root && Raven.configuration.project_root.to_s
+      end
+
+      def longest_load_path
+        $LOAD_PATH.select { |s| self.abs_path.start_with?(s.to_s) }.sort_by { |s| s.to_s.length }.last
       end
 
       def to_hash(*args)


### PR DESCRIPTION
Stack trace filenames are currently normalized based on the project root if they're under it, or the load path otherwise. This works for gems when they're installed globally, since they'll be outside the project root and the load path will be used. If the gems are installed into `vendor/` under the project root however, the full relative path will be used - which includes the gem version, e.g:

```
vendor/bundle/ruby/2.1.0/gems/activesupport-4.1.9/lib/active_support/callbacks.rb
```

This means that if you update a gem, any backtraces that pass through it will change and Sentry will see them as new events. Ideally we would always normalize based on the load path for gems, but use the project root for application code.

Instead of introducing a special case for load paths under `vendor/`, I've used the `in_app` attribute to decide whether to ignore the load path.

With this change, there are now three cases:

- When a path is under the project root and matches `APP_DIRS_PATTERN`, normalize it based on the project root.

- When a path is under the project root but doesn't match the pattern, first try to normalize it based on the load path, but fall back to using the project root.

- When a path is outside the project root, normalize it based on the load path.