### PR TITLE
Raven::Transports::HTTP#send should return response

### DIFF
--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -17,6 +17,7 @@ module Raven
           req.body = data
         end
         Raven.logger.warn "Error from Sentry server (#{response.status}): #{response.body}" unless response.status == 200
+        response
       end
 
       private


### PR DESCRIPTION
I'm writing another transport class which uses Raven::Transports::HTTP internally.
I'd like to know what is the response of HTTP#send, especially whether it returns 429 or not.