### PR TITLE
Fix raven:test NoMethodError: undefined method `id` for Hash error

### DIFF
--- a/lib/raven/cli.rb
+++ b/lib/raven/cli.rb
@@ -47,7 +47,11 @@ module Raven
       end
 
       if evt && !(evt.is_a? Thread)
-        puts "-> event ID: #{evt.id}"
+        if evt.is_a? Hash
+          puts "-> event ID: #{evt[:event_id]}"
+        else
+          puts "-> event ID: #{evt.id}"
+        end
       elsif evt #async configuration
         puts "-> event ID: #{evt.value.id}"
       else

--- a/spec/raven/cli_spec.rb
+++ b/spec/raven/cli_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe "CLI tests" do
+
+  example "posting an exception" do
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post('sentry/api/42/store/') { [200, {}, 'ok'] }
+    end
+
+    Raven.configure do |config|
+      config.server = 'http://12345:67890@sentry.localdomain/sentry/42'
+      config.environments = ["test"]
+      config.current_environment = "test"
+      config.http_adapter = [:test, stubs]
+    end
+
+    expect { Raven::CLI.test }.not_to raise_error
+
+    stubs.verify_stubbed_calls
+  end
+
+  example "posting an exception to a prefixed DSN" do
+
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post('/prefix/sentry/api/42/store/') { [200, {}, 'ok'] }
+    end
+
+    Raven.configure do |config|
+      config.environments = ["test"]
+      config.current_environment = "test"
+      config.http_adapter = [:test, stubs]
+    end
+
+    expect {
+      Raven::CLI.test 'http://12345:67890@sentry.localdomain/prefix/sentry/42'
+    }.not_to raise_error
+
+    stubs.verify_stubbed_calls
+  end
+end


### PR DESCRIPTION
When running `rake raven:test`, the task exits with NoMethodError: undefined method `id` for #<Hash:...> error. This is because `Raven.capture_exception(e)` returns a hash representation of `Raven:Event`, so `event.id` leads to an error. This PR checks whether the returned event is a Hash, and if so, retrieves the id from it.