### PR TITLE
Fix event hash lookup

### DIFF
--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -32,7 +32,7 @@ module Raven
         return
       end
 
-      Raven.logger.debug "Sending event #{event['id']} to Sentry"
+      Raven.logger.debug "Sending event #{event[:event_id]} to Sentry"
 
       content_type, encoded_data = encode(event)
 
@@ -73,7 +73,7 @@ module Raven
     end
 
     def get_log_message(event)
-      (event && event['message']) || '<no message value>'
+      (event && event[:message]) || '<no message value>'
     end
 
     def transport

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -21,7 +21,7 @@ describe "Integration tests" do
 
     stubs.verify_stubbed_calls
 
-    expect(io.string).to match(/Sending event \h+ to Sentry$/)
+    expect(io.string).to match(/Sending event [0-9a-f]+ to Sentry$/)
   end
 
   example "posting an exception to a prefixed DSN" do


### PR DESCRIPTION
Event keys are symbolized at #256, but they're looked up by String
at #300.