### PR TITLE
Include the delayed job id as a tag

### DIFF
--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -15,7 +15,8 @@ module Delayed
             ::Raven.capture_exception(exception,
               :logger  => 'delayed_job',
               :tags    => {
-                 :delayed_job_queue => job.queue
+                 :delayed_job_queue => job.queue,
+                 :delayed_job_id => job.id
               },
               :extra => {
                   :delayed_job => {


### PR DESCRIPTION
Makes it easier to see how many unique jobs are causing a
particular failure as opposed to retries of the same few jobs.