### PR TITLE
Ensure that the tags hierarchy is respected where event > context > configuration for tags using the same key

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -56,8 +56,12 @@ module Raven
 
       @user.merge!(@context.user)
       @extra.merge!(@context.extra)
+
+      tags = @tags.dup
+      @tags = {}
       @tags.merge!(@configuration.tags)
       @tags.merge!(@context.tags)
+      @tags.merge!(tags)
 
       # Some type coercion
       @timestamp  = @timestamp.strftime('%Y-%m-%dT%H:%M:%S') if @timestamp.is_a?(Time)

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -230,6 +230,50 @@ describe Raven::Event do
     end
   end
 
+  context 'tags hierarchy respected' do
+    let(:hash) do
+      config = Raven::Configuration.new
+      config.tags = {
+          'configuration_context_event_key' => 'configuration_value',
+          'configuration_context_key' => 'configuration_value',
+          'configuration_event_key' => 'configuration_value',
+          'configuration_key' => 'configuration_value',
+      }
+
+      Raven.tags_context({
+        'configuration_context_event_key' => 'context_value',
+        'configuration_context_key' => 'context_value',
+        'context_event_key' => 'context_value',
+        'context_key' => 'context_value',
+      })
+
+      Raven::Event.new(
+        :level => 'warning',
+        :logger => 'foo',
+        :tags => {
+          'configuration_context_event_key' => 'event_value',
+          'configuration_event_key' => 'event_value',
+          'context_event_key' => 'event_value',
+          'event_key' => 'event_value',
+        },
+        :server_name => 'foo.local',
+        :configuration => config
+      ).to_hash
+    end
+
+    it 'merges tags data' do
+      expect(hash[:tags]).to eq({
+        'configuration_context_event_key' => 'event_value',
+        'configuration_context_key' => 'context_value',
+        'configuration_event_key' => 'event_value',
+        'context_event_key' => 'event_value',
+        'configuration_key' => 'configuration_value',
+        'context_key' => 'context_value',
+        'event_key' => 'event_value',
+      })
+    end
+  end
+
   describe '.initialize' do
     it 'should not touch the env object for an ignored environment' do
       Raven.configure do |config|


### PR DESCRIPTION
In the wiki, when talking about [setting tags in the default configuration](https://github.com/getsentry/raven-ruby/wiki/Advanced-Configuration#tags) it sounded to me like you could override the values for each of the keys set in `tags`.

`You can configure default tags to be sent with every event. These can be overridden in the context or event.`

With the way the tags are merged together currently, the priority of *tags with the same key* is context > configuration > event.

This seems wrong to me as I would think that if you set a tag explicitly in the event that is being sent to Sentry that it should take precedence over context and configuration tag values.

I've made a change to work the way I would imagine it should work.