### PR TITLE
Change `Rails.inject` to look for the `railties` gem, not `rails`.

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -195,7 +195,7 @@ module Raven
 
     # Injects various integrations
     def inject
-      available_integrations = %w[delayed_job rails sidekiq rack rake]
+      available_integrations = %w[delayed_job railties sidekiq rack rake]
       integrations_to_load = available_integrations & Gem.loaded_specs.keys
       # TODO(dcramer): integrations should have some additional checks baked-in
       # or we should break them out into their own repos. Specifically both the

--- a/lib/raven/integrations/railties.rb
+++ b/lib/raven/integrations/railties.rb
@@ -1,0 +1,1 @@
+require 'raven/integrations/rails'


### PR DESCRIPTION
`rails` is a meta gem that can be skipped in a Rails app if we don't want to install gems like `actionmailer`, `activerecord` or `activejob`, while the `railties` gem is always present in a Rails app.

To ensure that Raven is properly loaded when the `rails` gem is not present we look for the `railties` gem, not `rails` in the `Gem.loaded_specs` Hash.