### PR TITLE
Use event_id instead of id if async+thread enabled

### DIFF
--- a/lib/raven/cli.rb
+++ b/lib/raven/cli.rb
@@ -53,7 +53,11 @@ module Raven
           puts "-> event ID: #{evt.id}"
         end
       elsif evt #async configuration
-        puts "-> event ID: #{evt.value.id}"
+        if evt.value.is_a? Hash
+          puts "-> event ID: #{evt.value[:event_id]}"
+        else
+          puts "-> event ID: #{evt.value.id}"
+        end
       else
         puts ""
         puts "An error occurred while attempting to send the event."


### PR DESCRIPTION
## How to raise bug
```bash
# use you dsn
$ bundle exec rake "raven:test[https://foo:bar@app.getsentry.com/1234]"

Client configuration:
-> server: https://app.getsentry.com
-> project_id: 1234
-> public_key: blabla...
-> secret_key: blabla...

Sending a test event:
rake aborted!
NoMethodError: undefined method `id' for #<Hash:0x007f71af480fa8>
```

## why occur?
When async is enabled, evt.value is like...
```
{:event_id=>"401ed3befbb0bb5d10807213b8d35c1a", :message=>"ZeroDivisionError: divided by 0", :timestamp=>"2015-05-01T07:55:15", ....
```
1. evt.value is not object. It is a hash
2. **event_id**, not **id**

## Related issue / pull request
* https://github.com/getsentry/raven-ruby/issues/203