### PR TITLE
Add support for ActiveJob.

### DIFF
--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -14,6 +14,13 @@ module Raven
       end
     end
 
+    initializer 'raven.active_job' do
+      ActiveSupport.on_load :active_job do
+        require 'raven/integrations/rails/active_job'
+        include Raven::Rails::ActiveJob
+      end
+    end
+
     config.after_initialize do
       Raven.configure do |config|
         config.logger ||= ::Rails.logger

--- a/lib/raven/integrations/rails/active_job.rb
+++ b/lib/raven/integrations/rails/active_job.rb
@@ -1,0 +1,18 @@
+module Raven
+  class Rails
+    module ActiveJob
+      def self.included(base)
+        base.class_eval do
+          rescue_from(Exception) do |exception|
+            # Do not capture exceptions when using Sidekiq so we don't capture
+            # The same exception twice.
+            unless self.class.queue_adapter.to_s == 'ActiveJob::QueueAdapters::SidekiqAdapter'
+              Raven.capture_exception(exception, :extra => { :active_job => self.class.name })
+              raise exception
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR has some of the initial code to add support for Active Job subclasses regardless of the queue backend that is being used - Raven currently supports Sidekiq on it's own but would be nice to have a broader support for other backends like SuckerPunch (the one I'm using), Resque, DelayedJob, etc.

I couldn't find any tests for the Sidekiq support to use as a base, but I'm take this to a spin in our app to see how it goes. Also, I fear that loading both the ActiveJob support + Sidekiq might generate duplicate reports since both integrations would be executed together, but this is something that I need to test it out to be sure about it.