### PR TITLE
config to allow disabling credit card number sanitization

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -95,6 +95,9 @@ module Raven
     # additional fields to sanitize
     attr_accessor :sanitize_fields
 
+    # Sanitize values that look like credit card numbers
+    attr_accessor :sanitize_credit_cards
+
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
                       'ActionController::InvalidAuthenticityToken',
@@ -119,6 +122,7 @@ module Raven
       self.async = false
       self.catch_debugged_exceptions = true
       self.sanitize_fields = []
+      self.sanitize_credit_cards = true
       self.environments = []
     end
 

--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -6,11 +6,12 @@ module Raven
     DEFAULT_FIELDS = %w(authorization password passwd secret ssn social(.*)?sec)
     CREDIT_CARD_RE = /^(?:\d[ -]*?){13,16}$/
 
-    attr_accessor :sanitize_fields
+    attr_accessor :sanitize_fields, :sanitize_credit_cards
 
     def initialize(client)
       super
       self.sanitize_fields = client.configuration.sanitize_fields
+      self.sanitize_credit_cards = client.configuration.sanitize_credit_cards
     end
 
     def process(value)
@@ -49,7 +50,8 @@ module Raven
     end
 
     def matches_regexes?(k, v)
-      CREDIT_CARD_RE.match(v.to_s) || fields_re.match(k.to_s)
+      (sanitize_credit_cards && CREDIT_CARD_RE.match(v.to_s)) ||
+        fields_re.match(k.to_s)
     end
 
     def fields_re
@@ -65,4 +67,3 @@ module Raven
     end
   end
 end
-


### PR DESCRIPTION
This allows for still using SanitizeData, while disabling this specific value
sanitizer, which is broad enough to capture any other 13-16 digit numbers as well.

As discussed in https://github.com/getsentry/raven-ruby/issues/328

Overall I kinda liked my second suggestion better, splitting the credit card sanitizer into a separate processor, but decided against it for backwards compatibility reasons. It'd be sad if people suddenly lost that sanitization because they were doing something like

```ruby
config.processors = [Raven::Processor::SanitizeData, MyCustomProcessor]
```