### PR TITLE
Make user and extra context merge order match tags

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -54,14 +54,9 @@ module Raven
 
       init.each_pair  { |key, val| instance_variable_set('@' + key.to_s, val) }
 
-      @user.merge!(@context.user)
-      @extra.merge!(@context.extra)
-
-      tags = @tags.dup
-      @tags = {}
-      @tags.merge!(@configuration.tags)
-      @tags.merge!(@context.tags)
-      @tags.merge!(tags)
+      @user = @context.user.merge(@user)
+      @extra = @context.extra.merge(@extra)
+      @tags = @configuration.tags.merge(@context.tags).merge(@tags)
 
       # Some type coercion
       @timestamp  = @timestamp.strftime('%Y-%m-%dT%H:%M:%S') if @timestamp.is_a?(Time)

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -274,6 +274,58 @@ describe Raven::Event do
     end
   end
 
+  context 'merging user context' do
+    before do
+      Raven.user_context({
+        'context_event_key' => 'context_value',
+        'context_key' => 'context_value',
+      })
+    end
+
+    let(:hash) do
+      Raven::Event.new({
+        :user => {
+          'context_event_key' => 'event_value',
+          'event_key' => 'event_value',
+        },
+      }).to_hash
+    end
+
+    it 'prioritizes event context over request context' do
+      expect(hash[:user]).to eq({
+        'context_event_key' => 'event_value',
+        'context_key' => 'context_value',
+        'event_key' => 'event_value',
+      })
+    end
+  end
+
+  context 'merging extra context' do
+    before do
+      Raven.extra_context({
+        'context_event_key' => 'context_value',
+        'context_key' => 'context_value',
+      })
+    end
+
+    let(:hash) do
+      Raven::Event.new({
+        :extra => {
+          'context_event_key' => 'event_value',
+          'event_key' => 'event_value',
+        },
+      }).to_hash
+    end
+
+    it 'prioritizes event context over request context' do
+      expect(hash[:extra]).to eq({
+        'context_event_key' => 'event_value',
+        'context_key' => 'context_value',
+        'event_key' => 'event_value',
+      })
+    end
+  end
+
   describe '.initialize' do
     it 'should not touch the env object for an ignored environment' do
       Raven.configure do |config|


### PR DESCRIPTION
Followup to #322.

Tags passed when capturing an event override tags in the request context. For consistency, user and extra context should behave the same way.