### PR TITLE
Use send_event when capturing an exception

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -78,7 +78,7 @@ module Raven
     #
     # @example
     #   evt = Raven::Event.new(:message => "An error")
-    #   Raven.send(evt)
+    #   Raven.send_event(evt)
     def send_event(event)
       client.send_event(event)
     end
@@ -119,7 +119,7 @@ module Raven
         if configuration.async?
           configuration.async.call(evt)
         else
-          send(evt)
+          send_event(evt)
         end
       end
     end

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -55,7 +55,7 @@ describe "Integration tests" do
       config.http_adapter = [:test, stubs]
     end
 
-    expect(Raven.logger).to receive(:warn).exactly(2).times
+    expect(Raven.logger).to receive(:warn).once
     expect { Raven.capture_exception(build_exception) }.not_to raise_error
 
     stubs.verify_stubbed_calls

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -5,7 +5,7 @@ describe Raven do
   let(:options) { double("options") }
 
   before do
-    allow(Raven).to receive(:send)
+    allow(Raven).to receive(:send_event)
     allow(Raven::Event).to receive(:from_message) { event }
     allow(Raven::Event).to receive(:from_exception) { event }
   end
@@ -15,7 +15,7 @@ describe Raven do
 
     it 'sends the result of Event.capture_message' do
       expect(Raven::Event).to receive(:from_message).with(message, options)
-      expect(Raven).to receive(:send).with(event)
+      expect(Raven).to receive(:send_event).with(event)
 
       Raven.capture_message(message, options)
     end
@@ -30,7 +30,7 @@ describe Raven do
 
     it 'sends the result of Event.capture_message' do
       expect(Raven::Event).to receive(:from_message).with(message, options)
-      expect(Raven).not_to receive(:send).with(event)
+      expect(Raven).not_to receive(:send_event).with(event)
 
       prior_async = Raven.configuration.async
       Raven.configuration.async = lambda { :ok }
@@ -45,7 +45,7 @@ describe Raven do
 
     it 'sends the result of Event.capture_exception' do
       expect(Raven::Event).to receive(:from_exception).with(exception, options)
-      expect(Raven).to receive(:send).with(event)
+      expect(Raven).to receive(:send_event).with(event)
 
       Raven.capture_exception(exception, options)
     end
@@ -60,7 +60,7 @@ describe Raven do
 
     it 'sends the result of Event.capture_exception' do
       expect(Raven::Event).to receive(:from_exception).with(exception, options)
-      expect(Raven).not_to receive(:send).with(event)
+      expect(Raven).not_to receive(:send_event).with(event)
 
       prior_async = Raven.configuration.async
       Raven.configuration.async = lambda { :ok }
@@ -74,7 +74,7 @@ describe Raven do
     let(:exception) { build_exception }
 
     it 'sends the result of Event.capture_exception according to the result of should_capture' do
-      expect(Raven).not_to receive(:send).with(event)
+      expect(Raven).not_to receive(:send_event).with(event)
 
       prior_should_capture = Raven.configuration.should_capture
       Raven.configuration.should_capture = Proc.new { false }


### PR DESCRIPTION
`Raven.send`, which happens to be used from `Raven.capture_type` is deprecated, and causes deprecation warnings. I would count this as a bug, because the end user cannot directly avoid the warning if they use `Raven.capture_type` directly—or in our case using it through the Rack integration middleware.

This PR makes `capture_type` use `send_event` and avoid the warning altogether, and changes the specs to match. 

All green: 170 examples, 0 failures.

Thanks!