### PR TITLE
Capture exceptions in runner tasks

### DIFF
--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -34,5 +34,9 @@ module Raven
     rake_tasks do
       require 'raven/integrations/tasks'
     end
+
+    runner do
+      Raven.capture
+    end
   end
 end


### PR DESCRIPTION
Fixes #325.

Install Raven's `at_exit` hook whenever `rails runner` is invoked so that if an exception occurs during the task it will be reported.

I'm not really sure how to write a good test for this, but from manual testing it seems to work.