### PR TITLE
Capture exceptions swallowed by rails

### DIFF
--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -60,7 +60,7 @@ module Raven
         raise
       end
 
-      error = env['rack.exception'] || env['sinatra.error']
+      error = env['rack.exception'] || env['sinatra.error'] || env['action_dispatch.exception']
 
       Raven::Rack.capture_exception(error, env) if error
 

--- a/spec/raven/integrations/rack_spec.rb
+++ b/spec/raven/integrations/rack_spec.rb
@@ -46,6 +46,22 @@ describe Raven::Rack do
     stack.call(env)
   end
 
+  it 'should capture rails errors' do
+    exception = build_exception
+    env = {}
+
+    expect(Raven::Rack).to receive(:capture_exception).with(exception, env)
+
+    app = lambda do |e|
+      e['action_dispatch.exception'] = exception
+      [200, {}, ['okay']]
+    end
+
+    stack = Raven::Rack.new(app)
+
+    stack.call(env)
+  end
+
   it 'should clear context after app is called' do
     Raven::Context.current.tags[:environment] = :test
 

--- a/spec/raven/integrations/rack_spec.rb
+++ b/spec/raven/integrations/rack_spec.rb
@@ -46,7 +46,7 @@ describe Raven::Rack do
     stack.call(env)
   end
 
-  it 'should capture rails errors' do
+  it 'should capture rails errors when ActionDispatch::ShowExceptions is enabled' do
     exception = build_exception
     env = {}
 


### PR DESCRIPTION
ActionDispatch's ShowExceptions swallows exceptions and stores the cause
in a rack env variable "action_dispatch.exception". Use this to report
on any exceptions swallowed by ShowExceptions.
