### PR TITLE
Change okjson to encode NaN and Infinity as string, instead of raising error.

### DIFF
--- a/lib/raven/okjson.rb
+++ b/lib/raven/okjson.rb
@@ -499,7 +499,7 @@ private
 
   def numenc(x)
     if ((x.nan? || x.infinite?) rescue false)
-      raise Error, "Numeric cannot be represented: #{x}"
+      return strenc(x.to_s)
     end
     "#{x}"
   end

--- a/spec/raven/okjson_spec.rb
+++ b/spec/raven/okjson_spec.rb
@@ -23,9 +23,11 @@ describe Raven::OkJson do
   it 'encodes anything that responds to to_s' do
     data = [
       (1..5),
-      :symbol
+      :symbol,
+      1/0.0,
+      0/0.0
     ]
-    expect(Raven::OkJson.encode(data)).to eq "[\"1..5\",\"symbol\"]"
+    expect(Raven::OkJson.encode(data)).to eq "[\"1..5\",\"symbol\",\"Infinity\",\"NaN\"]"
   end
 
   it 'does not parse scientific notation' do


### PR DESCRIPTION
In reference to issue #340 .

Just did the simplest thing that would work, tried to follow coding style of okjson.

Let me know if you want any changes.