### PR TITLE
Sanitize the query string when the key is a symbol instead of a string.

### DIFF
--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -23,7 +23,7 @@ module Raven
         process(v)
       elsif v.is_a?(Array)
         v.map{|a| sanitize(k, a)}
-      elsif k == 'query_string'
+      elsif k.to_s == 'query_string'
         sanitize_query_string(v)
       elsif v.is_a?(Integer) && matches_regexes?(k,v)
         INT_MASK

--- a/spec/raven/processors/sanitizedata_processor_spec.rb
+++ b/spec/raven/processors/sanitizedata_processor_spec.rb
@@ -152,6 +152,21 @@ describe Raven::Processor::SanitizeData do
       expect(vars["query_string"]).to_not include("secret")
     end
 
+    it 'handles :query_string as symbol' do
+      data = {
+        'sentry.interfaces.Http' => {
+          'data' => {
+            :query_string => 'foo=bar&password=secret'
+          }
+        }
+      }
+
+      result = @processor.process(data)
+
+      vars = result["sentry.interfaces.Http"]["data"]
+      expect(vars[:query_string]).to_not include("secret")
+    end
+
     it 'handles multiple values for a key' do
       data = {
         'sentry.interfaces.Http' => {


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-ruby/issues/341