### PR TITLE
Fix rack/lint errors

### DIFF
--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -23,8 +23,8 @@ module Raven
   class Rack
 
     def self.capture_type(exception, env, options = {})
-      if env['requested_at']
-        options[:time_spent] = Time.now - env['requested_at']
+      if env['raven.requested_at']
+        options[:time_spent] = Time.now - env['raven.requested_at']
       end
       Raven.capture_type(exception, options) do |evt|
         evt.interface :http do |int|
@@ -47,7 +47,7 @@ module Raven
 
       # store the current environment in our local context for arbitrary
       # callers
-      env['requested_at'] = Time.now
+      env['raven.requested_at'] = Time.now
       Raven.rack_context(env)
 
       begin

--- a/spec/raven/integrations/rack_spec.rb
+++ b/spec/raven/integrations/rack_spec.rb
@@ -78,4 +78,15 @@ describe Raven::Rack do
     stack.call(env)
   end
 
+  it 'should pass rack/lint' do
+    env = Rack::MockRequest.env_for("/test")
+
+    app = lambda do |e|
+      [200, {'Content-Type' => 'text/plain'}, ['OK']]
+    end
+
+    stack = Raven::Rack.new(Rack::Lint.new(app))
+    expect { stack.call(env) }.to_not raise_error(Rack::Lint::LintError)
+  end
+
 end


### PR DESCRIPTION
* The rack spec states that keys added by the application should contain
  one dot and be prefixed by something unique. In addition, it states that
  top level keys in the env should be string values only.
* Prior to this change, when running with rack/lint, you get the following error:
`Rack::Lint::LintError: env variable requested_at has non-string value 2015-07-28 17:16:36 +0000`
* Fixes #292