### PR TITLE
Remove Certifi and use default Ruby SSL config

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -1,4 +1,3 @@
-require 'certifi'
 require 'logger'
 require 'uri'
 
@@ -118,7 +117,6 @@ module Raven
       self.excluded_exceptions = IGNORE_DEFAULT
       self.processors = [Raven::Processor::RemoveCircularReferences, Raven::Processor::UTF8Conversion, Raven::Processor::SanitizeData]
       self.ssl_verification = true
-      self.ssl_ca_file = Certifi.where
       self.encoding = 'gzip'
       self.timeout = 1
       self.open_timeout = 1

--- a/sentry-raven.gemspec
+++ b/sentry-raven.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.license = 'Apache-2.0'
 
   gem.add_dependency "faraday", ">= 0.7.6"
-  gem.add_dependency "certifi"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
By default, Raven isn't actually using the SSL certificates it gets from Certifi. Because of a bug in Faraday, the default Net::HTTP adapter it uses, sets both `cert_store` + `ca_file`/`ca_path` on the same instance. The `cert_store` it defaults to is the Ruby default with system SSL paths and that takes precedence over `ca_file`/`ca_path`.

My suggestion is to remove Certifi and just use the Ruby defaults for SSL.