### PR TITLE
Use an empty hash if a false-y value is passed in

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -169,8 +169,8 @@ module Raven
     #
     # @example
     #   Raven.user_context('id' => 1, 'email' => 'foo@example.com')
-    def user_context(options = {})
-      self.context.user = options
+    def user_context(options = nil)
+      self.context.user = options || {}
     end
 
     # Bind tags context. Merges with existing context (if any).
@@ -180,8 +180,8 @@ module Raven
     #
     # @example
     #   Raven.tags_context('my_custom_tag' => 'tag_value')
-    def tags_context(options = {})
-      self.context.tags.merge!(options)
+    def tags_context(options = nil)
+      self.context.tags.merge!(options || {})
     end
 
     # Bind extra context. Merges with existing context (if any).
@@ -190,8 +190,8 @@ module Raven
     #
     # @example
     #   Raven.extra_context('my_custom_data' => 'value')
-    def extra_context(options = {})
-      self.context.extra.merge!(options)
+    def extra_context(options = nil)
+      self.context.extra.merge!(options || {})
     end
 
     def rack_context(env)


### PR DESCRIPTION
We were (in some cases) incorrectly passing in nil to `Raven.user_context()` which resulted in the following exception. This change will result in an empty hash being passed in if a false-y value (like nil) is passed in. 

`Error message
NoMethodError: undefined method `merge' for nil:NilClass

Stack trace (show Rails)
…ruby/2.2.0/gems/sentry-raven-0.13.3/lib/raven/
event.rb:  57:in `initialize'
…ruby/2.2.0/gems/sentry-raven-0.13.3/lib/raven/
event.rb: 132:in `new'
…ruby/2.2.0/gems/sentry-raven-0.13.3/lib/raven/
event.rb: 132:in `from_exception'
…/ruby/2.2.0/gems/sentry-raven-0.13.3/lib/raven/
base.rb: 117:in `capture_type'
…ems/sentry-raven-0.13.3/lib/raven/integrations/
rack.rb:  29:in `capture_type'`