### PR TITLE
Fix a problem with the at_exit error capturing

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -228,9 +228,9 @@ module Raven
 
     def install_at_exit_hook(options)
       at_exit do
-        if $ERROR_INFO
-          logger.debug "Caught a post-mortem exception: #{$ERROR_INFO.inspect}"
-          capture_exception($ERROR_INFO, options)
+        if $!
+          logger.debug "Caught a post-mortem exception: #{$!.inspect}"
+          capture_exception($!, options)
         end
       end
     end

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -156,7 +156,6 @@ describe Raven do
         captured_message = capture_in_separate_process { raise 'test error' }
         expect(captured_message).to eq('test error')
       end
-
     end
   end
 

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -125,7 +125,7 @@ describe Raven do
           described_class.capture(options)
 
           allow(Raven).to receive(:capture_exception) do |exception, options|
-            pipe_out.print exception.message
+            pipe_out.puts exception.message
           end
 
           # silence process
@@ -137,10 +137,11 @@ describe Raven do
         end
 
         pipe_out.close
-        captured_message = pipe_in.read
+        captured_messages = pipe_in.read
         pipe_in.close
 
-        captured_message
+        # sometimes the at_exit hook was registered multiple times
+        captured_messages.split("\n").last
       end
 
       it 'does not yield' do

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -117,6 +117,32 @@ describe Raven do
     context 'not given a block' do
       let(:options) { { :key => 'value' } }
 
+      def capture_in_separate_process
+        pipe_in, pipe_out = IO.pipe
+
+        fork do
+          pipe_in.close
+          described_class.capture(options)
+
+          allow(Raven).to receive(:capture_exception) do |exception, options|
+            pipe_out.print exception.message
+          end
+
+          # silence process
+          $stderr.reopen('/dev/null', 'w')
+          $stdout.reopen('/dev/null', 'w')
+
+          raise 'test error'
+          exit
+        end
+
+        pipe_out.close
+        captured_message = pipe_in.read
+        pipe_in.close
+
+        captured_message
+      end
+
       it 'does not yield' do
         # As there is no yield matcher that does not require a probe (e.g. this
         # is not valid: expect { |b| described_class.capture }.to_not yield_control),
@@ -125,10 +151,12 @@ describe Raven do
         expect { described_class.capture }.not_to raise_error
       end
 
-      it 'installs an at exit hook' do
-        expect(described_class).to receive(:install_at_exit_hook).with(options)
-        described_class.capture(options)
+      it 'installs an at exit hook that will capture exceptions' do
+        skip('fork not supported in jruby') if RUBY_PLATFORM == 'java'
+        captured_message = capture_in_separate_process { raise 'test error' }
+        expect(captured_message).to eq('test error')
       end
+
     end
   end
 


### PR DESCRIPTION
I've run into a problem where `Raven` did not capture errors in a `rails runner` task. It worked in `development` but not on `production`.

The issue is that `Raven` uses the `$ERROR_INFO` global variable. This is an alias for `$!`, but only if you first do a `require 'English'` (http://ruby-doc.org/stdlib-2.1.2/libdoc/English/rdoc/English.html).

I fixed it and added a test. If you're uncomfortable with the test (which has to do a `fork`), feel free to just pick the second commit.