### PR TITLE
Allow configurable integrations

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -12,8 +12,46 @@ features if you want.
    rails
    rack
 
-The following integrations are always available and cannot be configured:
+The following integrations are available :
 
-*   Sidekiq
-*   ``Delayed::Job``
-*   Rake
+*   Sidekiq (``:sidekiq``)
+*   ``Delayed::Job`` (``:delayed_job``)
+*   Rake (``:rake``)
+*   Rack (``:rack``)
+*   Rails (``:railties``)
+
+
+Manually using integrations
+---------------------------
+
+Integrations are automatically loaded by default. This can be problematic if
+the default integration behavior doesn't suit your projects' needs.
+
+To explicitly include integrations:
+
+::
+
+   require 'sentry-raven-without-integrations'
+   Raven.inject(:railties, :rack, :rake)
+
+
+To blacklist integrations:
+
+::
+
+   require 'sentry-raven-without-integrations'
+   Raven.inject_without(:sidekiq, :delayed_job)
+
+
+If you're using bundler, then in your gemfile:
+
+::
+
+   gem 'sentry-raven', require: 'sentry-raven-without-integrations'
+
+
+And in some sort of initializer:
+
+::
+
+   Raven.inject_without(:sidekiq)

--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -12,7 +12,7 @@ features if you want.
    rails
    rack
 
-The following integrations are available :
+The following integrations are available:
 
 *   Sidekiq (``:sidekiq``)
 *   ``Delayed::Job`` (``:delayed_job``)
@@ -32,7 +32,7 @@ To explicitly include integrations:
 ::
 
    require 'sentry-raven-without-integrations'
-   Raven.inject(:railties, :rack, :rake)
+   Raven.inject_only(:railties, :rack, :rake)
 
 
 To blacklist integrations:

--- a/lib/sentry-raven-without-integrations.rb
+++ b/lib/sentry-raven-without-integrations.rb
@@ -1,0 +1,1 @@
+require 'raven/base'


### PR DESCRIPTION
This allows inclusion of raven without automatic inclusion of integrations. 

For example, to use all default integrations without sidekiq:

```ruby
require 'sentry-raven-without-integrations'
Raven.inject_without(:sidekiq)
```

To only include railties:

```ruby
require 'sentry-raven-without-integrations'
Raven.inject_only(:ralties)
```

## Todos:

- [x] Specs
- [x] Actually test this out in a dummy app