### PR TITLE
sanitize should match strictly on whole words.

### DIFF
--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -132,13 +132,14 @@ describe Raven::Configuration do
 
   context 'configuration for sanitize fields' do
     it 'should union default sanitize fields with user-defined sanitize fields' do
-      fields = Raven::Processor::SanitizeData::DEFAULT_FIELDS | %w(test monkeybutt)
+      fields = Raven::Processor::SanitizeData::DEFAULT_FIELDS | %w(test monkeybutt foo(.*)?bar)
 
       subject.sanitize_fields = fields
       client = Raven::Client.new(subject)
       processor = Raven::Processor::SanitizeData.new(client)
+      expected_fields_re = /authorization|password|passwd|secret|ssn|social(.*)?sec|\btest\b|\bmonkeybutt\b|foo(.*)?bar/i
 
-      expect(processor.send(:fields_re)).to eq(/(#{fields.join('|')})/i)
+      expect(processor.send(:fields_re)).to eq(expected_fields_re)
     end
   end
 

--- a/spec/raven/processors/sanitizedata_processor_spec.rb
+++ b/spec/raven/processors/sanitizedata_processor_spec.rb
@@ -20,7 +20,8 @@ describe Raven::Processor::SanitizeData do
           'test' => 1,
           :ssn => '123-45-6789', # test symbol handling
           'social_security_number' => 123456789,
-          'user_field' => 'user'
+          'user_field' => 'user',
+          'user_field_foo' => 'hello'
         }
       }
     }
@@ -37,6 +38,7 @@ describe Raven::Processor::SanitizeData do
     expect(vars[:ssn]).to eq(Raven::Processor::SanitizeData::STRING_MASK)
     expect(vars["social_security_number"]).to eq(Raven::Processor::SanitizeData::INT_MASK)
     expect(vars["user_field"]).to eq(Raven::Processor::SanitizeData::STRING_MASK)
+    expect(vars["user_field_foo"]).to eq('hello')
   end
 
   it 'should filter json data' do
@@ -50,7 +52,8 @@ describe Raven::Processor::SanitizeData do
         'test' => 1,
         'ssn' => '123-45-6789',
         'social_security_number' => 123456789,
-        'user_field' => 'user'
+        'user_field' => 'user',
+        'user_field_foo' => 'hello'
         }.to_json
       }
 
@@ -66,6 +69,7 @@ describe Raven::Processor::SanitizeData do
     expect(vars["ssn"]).to eq(Raven::Processor::SanitizeData::STRING_MASK)
     expect(vars["social_security_number"]).to eq(Raven::Processor::SanitizeData::INT_MASK)
     expect(vars["user_field"]).to eq(Raven::Processor::SanitizeData::STRING_MASK)
+    expect(vars["user_field_foo"]).to eq('hello')
   end
 
   it 'should filter json embedded in a ruby object' do


### PR DESCRIPTION
We have a Rails app and one of our `filter_parameters` fields is name. Because of the loose matching on words, fields such as `server_name` get masked.