### PR TITLE
Expose more debugging info to active_job integration

### DIFF
--- a/lib/raven/integrations/rails/active_job.rb
+++ b/lib/raven/integrations/rails/active_job.rb
@@ -7,7 +7,14 @@ module Raven
             # Do not capture exceptions when using Sidekiq so we don't capture
             # The same exception twice.
             unless self.class.queue_adapter.to_s == 'ActiveJob::QueueAdapters::SidekiqAdapter'
-              Raven.capture_exception(exception, :extra => { :active_job => self.class.name })
+              Raven.capture_exception(exception, :extra => {
+                :active_job => self.class.name,
+                :arguments => arguments,
+                :scheduled_at => scheduled_at,
+                :job_id => job_id,
+                :provider_job_id => provider_job_id,
+                :locale => locale,
+              })
               raise exception
             end
           end


### PR DESCRIPTION
Aims to address https://github.com/getsentry/raven-ruby/issues/364

Although, now that I'm running into the issue alluded to here in the raven-ruby codebase: https://github.com/getsentry/raven-ruby/blob/master/lib/raven/integrations/rails/active_job.rb#L9 where it's capturing two exceptions - one for active job and one for resque...