### PR TITLE
Fix activejob integration

### DIFF
--- a/lib/raven/integrations/rails/active_job.rb
+++ b/lib/raven/integrations/rails/active_job.rb
@@ -7,14 +7,20 @@ module Raven
             # Do not capture exceptions when using Sidekiq so we don't capture
             # The same exception twice.
             unless self.class.queue_adapter.to_s == 'ActiveJob::QueueAdapters::SidekiqAdapter'
-              Raven.capture_exception(exception, :extra => {
+              active_job_details = {
                 :active_job => self.class.name,
                 :arguments => arguments,
                 :scheduled_at => scheduled_at,
                 :job_id => job_id,
-                :provider_job_id => provider_job_id,
                 :locale => locale,
-              })
+              }
+
+              # Add provider_job_id details if Rails 5
+              if defined?(provider_job_id)
+                active_job_details.merge!(:provider_job_id => provider_job_id)
+              end
+
+              Raven.capture_exception(exception, :extra => active_job_details)
               raise exception
             end
           end


### PR DESCRIPTION
Looks like this was developed against Rails 5, which isn't released yet. Until then we don't have access to `provider_job_id`, so the existing code will error out during the `Raven.capture_exception` call.