### PR TITLE
Only capture handled exceptions if they are 5xx and handled by default handler

### DIFF
--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -60,7 +60,7 @@ module Raven
         raise
       end
 
-      error = env['rack.exception'] || env['sinatra.error'] || env['action_dispatch.exception']
+      error = env['rack.exception'] || env['sinatra.error']
 
       Raven::Rack.capture_exception(error, env) if error
 

--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -36,6 +36,11 @@ module Raven
           ::ActionDispatch::ShowExceptions.send(:include, Raven::Rails::Middleware::DebugExceptionsCatcher)
         end
       end
+
+      if defined?(::ActionDispatch::PublicExceptions)
+        require 'raven/integrations/rails/middleware/public_exceptions_catcher'
+        ::ActionDispatch::PublicExceptions.send(:include, Raven::Rails::Middleware::PublicExceptionsCatcher)
+      end
     end
 
     rake_tasks do

--- a/lib/raven/integrations/rails/middleware/public_exceptions_catcher.rb
+++ b/lib/raven/integrations/rails/middleware/public_exceptions_catcher.rb
@@ -1,0 +1,16 @@
+module Raven
+  class Rails
+    module Middleware
+      module PublicExceptionsCatcher
+        def self.included(base)
+          base.send(:alias_method_chain, :call, :raven)
+        end
+
+        def call_with_raven(env)
+          Raven::Rack.capture_exception(env['action_dispatch.exception'], env)
+          call_without_raven(env)
+        end
+      end
+    end
+  end
+end

--- a/spec/raven/integrations/rack_spec.rb
+++ b/spec/raven/integrations/rack_spec.rb
@@ -46,22 +46,6 @@ describe Raven::Rack do
     stack.call(env)
   end
 
-  it 'should capture rails errors when ActionDispatch::ShowExceptions is enabled' do
-    exception = build_exception
-    env = {}
-
-    expect(Raven::Rack).to receive(:capture_exception).with(exception, env)
-
-    app = lambda do |e|
-      e['action_dispatch.exception'] = exception
-      [200, {}, ['okay']]
-    end
-
-    stack = Raven::Rack.new(app)
-
-    stack.call(env)
-  end
-
   it 'should clear context after app is called' do
     Raven::Context.current.tags[:environment] = :test
 
@@ -102,7 +86,7 @@ describe Raven::Rack do
     end
 
     stack = Raven::Rack.new(Rack::Lint.new(app))
-    expect { stack.call(env) }.to_not raise_error(Rack::Lint::LintError)
+    expect { stack.call(env) }.to_not raise_error
   end
 
 end


### PR DESCRIPTION
This is an attempt to make https://github.com/getsentry/raven-ruby/pull/343 less noisy.

The Rails `ShowExceptions` class wraps exceptions and calls a handler to decide what to do with them. The default hander is the `PublicExceptions` class. We only want to send exceptions to sentry by default when that default handler hasn't been overwritten (by setting an `exceptions_app` other than `PublicExceptions`).