### PR TITLE
Remove deprecated methods

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -85,12 +85,6 @@ module Raven
       client.send_event(event)
     end
 
-    def send(event)
-      Raven.logger.warn "DEPRECATION WARNING: Calling #send on Raven::Base will be \
-        removed in Raven-Ruby 0.14! Use #send_event instead!"
-      client.send_event(event)
-    end
-
     # Capture and process any exceptions from the given block, or globally if
     # no block is given
     #

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -49,12 +49,6 @@ module Raven
       event
     end
 
-    def send(event)
-      Raven.logger.warn "DEPRECATION WARNING: Calling #send on a Client will be \
-        removed in Raven-Ruby 0.14! Use #send_event instead!"
-      send_event(event)
-    end
-
     private
 
     def configuration_allows_sending

--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -19,12 +19,6 @@ module Raven
         response
       end
 
-      def send(auth_header, data, options = {})
-        Raven.logger.warn "DEPRECATION WARNING: Calling #send on a Transport will be \
-          removed in Raven-Ruby 0.14! Use #send_event instead!"
-        send_event(auth_header, data, options)
-      end
-
       private
 
       def conn

--- a/lib/raven/transports/udp.rb
+++ b/lib/raven/transports/udp.rb
@@ -10,12 +10,6 @@ module Raven
         conn.send "#{auth_header}\n\n#{data}", 0
       end
 
-      def send(auth_header, data, options = {})
-        Raven.logger.warn "DEPRECATION WARNING: Calling #send on a Transport will be \
-          removed in Raven-Ruby 0.14! Use #send_event instead!"
-        send_event(auth_header, data, options)
-      end
-
     private
 
       def conn


### PR DESCRIPTION
Looks like these were scheduled for deletion in 0.14.