### PR TITLE
Active Job w/ Delayed Job Backend

### DIFF
--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -12,27 +12,30 @@ module Delayed
 
           rescue Exception => exception
             # Log error to Sentry
+            extra = {
+              :delayed_job => {
+                :id          => job.id,
+                :priority    => job.priority,
+                :attempts    => job.attempts,
+                :handler     => job.handler,
+                :last_error  => job.last_error,
+                :run_at      => job.run_at,
+                :locked_at   => job.locked_at,
+                :locked_by   => job.locked_by,
+                :queue       => job.queue,
+                :created_at  => job.created_at
+                }
+            }
+            if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
+              extra.merge!(:active_job => job.payload_object.job_data)
+            end
             ::Raven.capture_exception(exception,
               :logger  => 'delayed_job',
               :tags    => {
                  :delayed_job_queue => job.queue,
                  :delayed_job_id => job.id
               },
-              :extra => {
-                  :delayed_job => {
-                      :id          => job.id,
-                      :priority    => job.priority,
-                      :attempts    => job.attempts,
-                      :handler     => job.handler,
-                      :last_error  => job.last_error,
-                      :run_at      => job.run_at,
-                      :locked_at   => job.locked_at,
-                      #failed_at  => job.failed_at,
-                      :locked_by   => job.locked_by,
-                      :queue       => job.queue,
-                      :created_at  => job.created_at
-                  }
-              })
+              :extra => extra)
 
             # Make sure we propagate the failure!
             raise exception


### PR DESCRIPTION
When an exception is caught from delayed job, but was sent via the Active Job backend, other information is available to fetch.

There were situations where only *last_error*, *locked_at*, and *queue* were in the additional data. Depending on point of failure, some of the active_job data may have been included.
This adds the *active_job* data, which may include *arguments*, *job_class*, the Active Job *job_id*, *locale*, and *queue_name*. The Active Job job_id is most useful, as it is included in the default tagged logging.