### PR TITLE
configuration.unsent_event for Unsent Events

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -85,6 +85,9 @@ module Raven
     # Optional Proc to be used to send events asynchronously.
     attr_reader :async
 
+    # Optional Proc to called if an event cannot be sent to Sentry
+    attr_reader :unsent_event
+
     # Exceptions from these directories to be ignored
     attr_accessor :app_dirs_pattern
 
@@ -123,6 +126,7 @@ module Raven
       self.proxy = nil
       self.tags = {}
       self.async = false
+      self.unsent_event = false
       self.catch_debugged_exceptions = true
       self.sanitize_fields = []
       self.sanitize_credit_cards = true
@@ -164,6 +168,13 @@ module Raven
     end
 
     alias_method :async?, :async
+
+    def unsent_event=(value)
+      raise ArgumentError.new("unsent_event must be callable (or false to disable)") unless (value == false || value.respond_to?(:call))
+      @unsent_event = value
+    end
+
+    alias_method :unsent_event?, :unsent_event
 
     # Allows config options to be read like a hash
     #

--- a/lib/raven/transports.rb
+++ b/lib/raven/transports.rb
@@ -2,8 +2,9 @@ require 'raven/error'
 
 module Raven
   module Transports
-    class Transport
+    class NonFatalConnectionError < StandardError; end
 
+    class Transport
       attr_accessor :configuration
 
       def initialize(configuration)

--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -15,7 +15,11 @@ module Raven
           req.headers['X-Sentry-Auth'] = auth_header
           req.body = data
         end
-        Raven.logger.warn "Error from Sentry server (#{response.status}): #{response.body}" unless response.status == 200
+
+        unless response.status == 200
+          raise Raven::Transports::NonFatalConnectionError, "Error from Sentry server (#{response.status}): #{response.body}"
+        end
+
         response
       end
 

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -46,6 +46,11 @@ describe Raven::Configuration do
       expect(subject[:async?]).to eq(false)
     end
 
+    it 'should not have unsent_event' do
+      expect(subject[:unsent_event]).to eq(false)
+      expect(subject[:unsent_event?]).to eq(false)
+    end
+
     it 'should catch_debugged_exceptions' do
       expect(subject[:catch_debugged_exceptions]).to eq(true)
     end
@@ -110,6 +115,20 @@ describe Raven::Configuration do
       expect { subject.async = lambda {} }.to_not raise_error
       expect { subject.async = false }.to_not raise_error
       expect { subject.async = true }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'configuring for server error callback' do
+    it 'should be configurable to send server errors to a callback' do
+      subject.unsent_event = lambda { |_e| :ok }
+      expect(subject.unsent_event.respond_to?(:call)).to eq(true)
+    end
+
+    it 'should raise when setting unsent_event to anything other than callable or false' do
+      expect { subject.unsent_event = Proc.new {} }.to_not raise_error
+      expect { subject.unsent_event = lambda {} }.to_not raise_error
+      expect { subject.unsent_event = false }.to_not raise_error
+      expect { subject.unsent_event = true }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
Thank you kindly for considering this PR. This PR addresses https://github.com/getsentry/raven-ruby/issues/376. It does this by implementing a configuration parameter `unsent_event` which is a Proc that is called if:

* the client is in a failure state and is not sending messages
* the server, when using the HTTPTransport, responds with a non-200 status code
* when the transport raises a runtime exception (HTTP, UDP, or any other transport)

Its semantics are similar to `async` — i.e. the default value for the parameter is `false` and we do some checking on the parameter just like `async` to make sure the value is `false` or a callable. These changes are near-robust. I spent quite a long time playing with writing tests in `raven_spec.rb`, but ran into some roadblocks and could use a little help if any maintainers have a spare moment.

Thank you again kindly for considering this PR. This enhancement will be greatly helpful for my active use of raven-ruby and Sentry.