### PR TITLE
Strip ActiveJob keys to prevent recursion

### DIFF
--- a/lib/raven/integrations/sidekiq.rb
+++ b/lib/raven/integrations/sidekiq.rb
@@ -23,6 +23,35 @@ if Sidekiq::VERSION < '3'
   end
 else
   Sidekiq.configure_server do |config|
-    config.error_handlers << Proc.new {|ex,context| Raven.capture_exception(ex, :extra => {:sidekiq => context}) }
+    config.error_handlers << Proc.new { |ex, context|
+      Raven.capture_exception(ex, :extra => {
+        :sidekiq => filter_context(context),
+      })
+    }
   end
+end
+
+def filter_context(context)
+  case context
+    when Array
+      context.map { |arg| filter_context(arg) }
+    when Hash
+      Hash[context.map { |key, value| filter_context_hash(key, value) }]
+    else
+      context
+    end
+end
+
+def filter_context_hash(key, value)
+  # Strip any `_aj` prefixes from keys.
+  # These keys come from an internal serialized object from ActiveJob.
+  # Internally, there are a subset of keys that ActiveJob references, but
+  # these are declared as private, and I don't think it's wise
+  # to keep chasing what this list is. But they all use a common prefix, so
+  # we want to strip this becuase ActiveJob will complain.
+  # e.g.: _aj_globalid -> _globalid
+  if key[0..3] == '_aj_'
+    key = key[3..-1]
+  end
+  [key, filter_context(value)]
 end


### PR DESCRIPTION
Once an ActiveJob is queued, ActiveRecord references get serialized into
some internal reserved keys, such as _aj_globalid.

The problem is, if this job in turn gets queued back into ActiveJob with
these magic reserved keys, ActiveJob will throw up and error. We want to
capture these and mutate the keys so we can sanely report it.

Fixes GH-384