### PR TITLE
No parentheses when method is called without arguments.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -358,12 +358,6 @@ Style/LeadingCommentSpace:
     - 'lib/raven/transports.rb'
 
 # Offense count: 1
-# Cop supports --auto-correct.
-Style/MethodCallParentheses:
-  Exclude:
-    - 'spec/raven/raven_spec.rb'
-
-# Offense count: 1
 Style/ModuleFunction:
   Exclude:
     - 'lib/raven/okjson.rb'

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -110,7 +110,7 @@ describe Raven do
 
       it 'does not install an exit_hook' do
         expect(described_class).not_to receive(:install_at_exit_hook)
-        described_class.capture() {}
+        described_class.capture {}
       end
     end
 


### PR DESCRIPTION
Fixes one place where method used parentheses when called without arguments.