### PR TITLE
Change == nil to .nil?

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -369,13 +369,6 @@ Style/NegatedIf:
     - 'lib/raven/client.rb'
     - 'lib/raven/okjson.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/NilComparison:
-  Exclude:
-    - 'lib/raven/linecache.rb'
-    - 'lib/raven/okjson.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: IncludeSemanticChanges.

--- a/lib/raven/linecache.rb
+++ b/lib/raven/linecache.rb
@@ -21,7 +21,7 @@ module Raven
       def getline(path, n)
         return nil if n < 1
         lines = getlines(path)
-        return nil if lines == nil
+        return nil if lines.nil?
         lines[n - 1]
       end
     end

--- a/lib/raven/okjson.rb
+++ b/lib/raven/okjson.rb
@@ -221,7 +221,7 @@ private
     ts = []
     while s.length > 0
       typ, lexeme, val = tok(s)
-      if typ == nil
+      if typ.nil?
         raise Error, "invalid character at #{s[0,10].inspect}"
       end
       if typ != :space


### PR DESCRIPTION
The style guide prefers x.nil? to x == nil. Changed in two places.