### PR TITLE
Correct non-nil check style.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -376,13 +376,6 @@ Style/NilComparison:
     - 'lib/raven/linecache.rb'
     - 'lib/raven/okjson.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: IncludeSemanticChanges.
-Style/NonNilCheck:
-  Exclude:
-    - 'lib/raven/linecache.rb'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 Style/NumericLiterals:

--- a/lib/raven/linecache.rb
+++ b/lib/raven/linecache.rb
@@ -7,7 +7,7 @@ module Raven
 
       def is_valid_file(path)
         lines = getlines(path)
-        return !lines.nil?
+        !lines.nil?
       end
 
       def getlines(path)

--- a/lib/raven/linecache.rb
+++ b/lib/raven/linecache.rb
@@ -7,7 +7,7 @@ module Raven
 
       def is_valid_file(path)
         lines = getlines(path)
-        return lines != nil
+        return !lines.nil?
       end
 
       def getlines(path)


### PR DESCRIPTION
Style guide prefers !x.nil? to x != nil.