### PR TITLE
Remove unused argument method + blocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   Exclude:
     - 'lib/raven/okjson.rb'
+
+Lint/UnusedMethodArgument:   
+  Exclude:   
+     - 'lib/raven/backports/uri.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,22 +26,6 @@ Lint/UnreachableCode:
   Exclude:
     - 'spec/raven/raven_spec.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoreEmptyBlocks.
-Lint/UnusedBlockArgument:
-  Exclude:
-    - 'spec/raven/integrations/rack_spec.rb'
-    - 'spec/raven/raven_spec.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods.
-Lint/UnusedMethodArgument:
-  Exclude:
-    - 'lib/raven/backports/uri.rb'
-    - 'lib/raven/processor.rb'
-
 # Offense count: 29
 Metrics/AbcSize:
   Max: 73

--- a/lib/raven/processor.rb
+++ b/lib/raven/processor.rb
@@ -4,7 +4,7 @@ module Raven
       @client = client
     end
 
-    def process(data)
+    def process(_data)
       raise NotImplementedError
     end
   end

--- a/spec/raven/integrations/rack_spec.rb
+++ b/spec/raven/integrations/rack_spec.rb
@@ -97,7 +97,7 @@ describe Raven::Rack do
   it 'should pass rack/lint' do
     env = Rack::MockRequest.env_for("/test")
 
-    app = lambda do |e|
+    app = proc do
       [200, {'Content-Type' => 'text/plain'}, ['OK']]
     end
 

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -30,7 +30,7 @@ describe Raven do
 
     around do |example|
       prior_async = Raven.configuration.async
-      Raven.configuration.async = lambda { |event| :ok }
+      Raven.configuration.async = Proc.new { :ok }
       example.run
       Raven.configuration.async = prior_async
     end
@@ -69,7 +69,7 @@ describe Raven do
 
     around do |example|
       prior_async = Raven.configuration.async
-      Raven.configuration.async = lambda { |event| :ok }
+      Raven.configuration.async = Proc.new { :ok }
       example.run
       Raven.configuration.async = prior_async
     end
@@ -124,7 +124,7 @@ describe Raven do
           pipe_in.close
           described_class.capture(options)
 
-          allow(Raven).to receive(:capture_exception) do |exception, options|
+          allow(Raven).to receive(:capture_exception) do |exception, _options|
             pipe_out.puts exception.message
           end
 


### PR DESCRIPTION
Mark all the unused stuff with the lodash prefix, so we know that they are not used.