### PR TITLE
Allow fixnums as hash key

### DIFF
--- a/lib/raven/okjson.rb
+++ b/lib/raven/okjson.rb
@@ -448,6 +448,7 @@ private
     case k
     when String then strenc(k)
     when Symbol then strenc(k.to_s)
+    when Fixnum then strenc(k.to_s)
     else
       raise Error, "Hash key is not a string: #{k.inspect}"
     end

--- a/spec/raven/okjson_spec.rb
+++ b/spec/raven/okjson_spec.rb
@@ -1,21 +1,27 @@
 require 'spec_helper'
 
 describe Raven::OkJson do
-  ['foo', :foo].each do |obj|
-    it "works with #{obj.class} keys" do
-      expect(Raven::OkJson.encode(obj => 'bar')).to eq '{"foo":"bar"}'
+  data = [
+    OpenStruct.new(:key => 'foo', :val => 'bar', :enc_key => '"foo"', :enc_val => '"bar"'),
+    OpenStruct.new(:key => :foo, :val => :bar, :enc_key => '"foo"', :enc_val => '"bar"'),
+    OpenStruct.new(:key => 1, :val => 1, :enc_key => '"1"', :enc_val => '1')
+  ]
+
+  data.each do |obj|
+    it "works with #{obj.key.class} keys" do
+      expect(Raven::OkJson.encode(obj.key => 'bar')).to eq "{#{obj.enc_key}:\"bar\"}"
     end
 
-    it "works with #{obj.class} values" do
-      expect(Raven::OkJson.encode('bar' => obj)).to eq '{"bar":"foo"}'
+    it "works with #{obj.val.class} values" do
+      expect(Raven::OkJson.encode('bar' => obj.val)).to eq "{\"bar\":#{obj.enc_val}}"
     end
 
-    it "works with an array of #{obj.class}s" do
-      expect(Raven::OkJson.encode('bar' => [obj])).to eq '{"bar":["foo"]}'
+    it "works with an array of #{obj.val.class}s" do
+      expect(Raven::OkJson.encode('bar' => [obj.val])).to eq "{\"bar\":[#{obj.enc_val}]}"
     end
 
-    it "works with a hash of #{obj.class}s" do
-      expect(Raven::OkJson.encode('bar' => {obj => obj})).to eq '{"bar":{"foo":"foo"}}'
+    it "works with a hash of #{obj.val.class}s" do
+      expect(Raven::OkJson.encode('bar' => {obj.key => obj.val})).to eq "{\"bar\":{#{obj.enc_key}:#{obj.enc_val}}}"
     end
   end
 


### PR DESCRIPTION
I got the error "Hash key is not a string" for a number in one of my apps during encoding of the data to be sent. I am not entirely sure where it came from since I wasn't able to reproduce that problem locally. My current assumption is that it was some key set during `Raven.user_context`.

While it could be said that the application is to blame for this, I think Sentry should be more forgiving. After all, Sentry is meant to collect errors, not produce any :) Sentry should do whatever it can to report errors in my application, no matter what is being thrown at it. In that light, I wonder whether "okjson" is the right way to do JSON encoding at all. From their repo:

> Note for people who've used other ruby json
libraries: json does not represent symbols,
so okjson does not encode them. It won't
convert them to strings; that would silently
corrupt your data. The same holds for all of
ruby's other data types that don't exist in
json, including Range, Regexp, Proc, Time,
and user-defined classes.

Sentry should not be concerned with "corrupting data". Already Sentry is handling symbols in the vendored version since this is so common in Ruby. I think you're going to fight "upstream" okjson quite a bit going forward ...