### PR TITLE
If Rails runner undefined, just skip it

### DIFF
--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -35,8 +35,10 @@ module Raven
       require 'raven/integrations/tasks'
     end
 
-    runner do
-      Raven.capture
+    if defined?(runner)
+      runner do
+        Raven.capture
+      end
     end
   end
 end


### PR DESCRIPTION
Not sure what Rails version is triggering this, but this should fix #350