### PR TITLE
Fix DelayedJob with handlers

### DIFF
--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -17,7 +17,9 @@ module Delayed
                 :id          => job.id,
                 :priority    => job.priority,
                 :attempts    => job.attempts,
-                :handler     => job.handler,
+                # handlers are YAML objects in strings, we definitely can't
+                # report all of that or the event will get truncated randomly
+                :handler     => job.handler[0...100],
                 :last_error  => job.last_error,
                 :run_at      => job.run_at,
                 :locked_at   => job.locked_at,


### PR DESCRIPTION
Handlers are YAML, so if they're big, the event will get truncated and
data will be lost. That's bad! Instead, just send the first 100
characters of the handler YAML.