### PR TITLE
⚠️ Ruby Warnings

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -152,7 +152,7 @@ module Raven
     #                              'email' => 'foo@example.com' })
     #   end
     def annotate_exception(exc, options = {})
-      notes = exc.instance_variable_get(:@__raven_context) || {}
+      notes = (exc.instance_variable_defined?(:@__raven_context) && exc.instance_variable_get(:@__raven_context)) || {}
       notes.merge!(options)
       exc.instance_variable_set(:@__raven_context, notes)
       exc

--- a/lib/raven/cli.rb
+++ b/lib/raven/cli.rb
@@ -1,5 +1,3 @@
-require 'raven'
-
 module Raven
   class CLI
     def self.test(dsn = nil)

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -177,16 +177,16 @@ module Raven
         end
         exceptions.reverse!
 
-        exc_int.values = exceptions.map do |exc|
+        exc_int.values = exceptions.map do |e|
           SingleExceptionInterface.new do |int|
-            int.type = exc.class.to_s
-            int.value = exc.to_s
-            int.module = exc.class.to_s.split('::')[0...-1].join('::')
+            int.type = e.class.to_s
+            int.value = e.to_s
+            int.module = e.class.to_s.split('::')[0...-1].join('::')
 
             int.stacktrace =
-              if exc.backtrace
+              if e.backtrace
                 StacktraceInterface.new do |stacktrace|
-                  stacktrace_interface_from(stacktrace, evt, exc.backtrace)
+                  stacktrace_interface_from(stacktrace, evt, e.backtrace)
                 end
               end
           end

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -121,7 +121,7 @@ module Raven
     end
 
     def self.from_exception(exc, options = {}, &block)
-      notes = exc.instance_variable_get(:@__raven_context) || {}
+      notes = (exc.instance_variable_defined?(:@__raven_context) && exc.instance_variable_get(:@__raven_context)) || {}
       options = notes.merge(options)
 
       configuration = options[:configuration] || Raven.configuration

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -32,6 +32,7 @@ module Raven
       @interfaces    = {}
       @context       = Raven.context
       @id            = generate_event_id
+      @project       = nil
       @message       = nil
       @timestamp     = Time.now.utc
       @time_spent    = nil

--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -1,4 +1,3 @@
-require 'raven'
 require 'rails'
 
 module Raven

--- a/lib/raven/integrations/tasks.rb
+++ b/lib/raven/integrations/tasks.rb
@@ -1,5 +1,4 @@
 require 'rake'
-require 'raven'
 require 'raven/cli'
 
 namespace :raven do


### PR DESCRIPTION
This PR eliminates several Ruby warnings.

`require 'raven'`  has been removed here and there in order to fix the circular require warning, which is totally safe because `require 'raven'` has to be already performed by bundler => lib/sentry-raven.rb.