### PR TITLE
Use the real Rails object to get REVISION file location

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -419,7 +419,7 @@ Style/StringLiterals:
 # Offense count: 33
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline, SupportedStyles.
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   Exclude:
     - 'lib/raven/configuration.rb'
     - 'lib/raven/event.rb'

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -133,7 +133,7 @@ module Raven
       self.release = ENV['HEROKU_SLUG_COMMIT']
 
       if self.release.nil? || self.release.empty?
-        self.release = File.read(File.join(Rails.root, 'REVISION')).strip rescue nil
+        self.release = File.read(File.join(::Rails.root, 'REVISION')).strip rescue nil
       end
 
       if self.release.nil? || self.release.empty?


### PR DESCRIPTION
Using sentry-raven 0.15.3 this is actually trying to call Raven::Rails.root instead of the actual Rails object.

The hidden exception (truncated):
```
railties-4.2.5/lib/rails/railtie.rb:196:in `method_missing': undefined method `root' for Raven::Rails:Class (NoMethodError)
sentry-raven-0.15.3/lib/raven/configuration.rb:136:in `initialize'
```