### PR TITLE
Stop writing a git error message to stderr

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -139,7 +139,7 @@ module Raven
       end
 
       if self.release.nil? || self.release.empty?
-        self.release = `git rev-parse --short HEAD`.strip rescue nil
+        self.release = `git rev-parse --short HEAD 2> /dev/null`.strip rescue nil
       end
     end
 


### PR DESCRIPTION
Executing `git rev-parse` out of git repository writes

    fatal: Not a git repository (or any of the parent directories): .git

to stderr.