### PR TITLE
Detect release before application initializers run

### DIFF
--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -13,7 +13,7 @@ module Raven
       end
     end
 
-    config.after_initialize do
+    config.before_initialize do
       Raven.configure do |config|
         config.logger ||= ::Rails.logger
         config.project_root ||= ::Rails.root

--- a/spec/raven/integrations/rails_spec.rb
+++ b/spec/raven/integrations/rails_spec.rb
@@ -7,6 +7,7 @@ describe TestApp, :type => :request do
     Raven.configure do |config|
       config.dsn = 'dummy://notaserver'
       config.encoding = 'json'
+      config.logger = nil
     end
     Rails.env = "production"
     TestApp.initialize!
@@ -34,5 +35,17 @@ describe TestApp, :type => :request do
     event = JSON.parse!(event[1])
 
     expect(event['request']['url']).to eq("http://www.example.com/exception")
+  end
+
+  it "sets Raven.configuration.logger correctly" do
+    expect(Raven.configuration.logger).to eq(Rails.logger)
+  end
+
+  it "sets Raven.configuration.project_root correctly" do
+    expect(Raven.configuration.project_root).to eq(Rails.root)
+  end
+
+  it "doesn't clobber a manually configured release" do
+    expect(Raven.configuration.release).to eq('beta')
   end
 end

--- a/spec/support/test_rails_app/app.rb
+++ b/spec/support/test_rails_app/app.rb
@@ -25,6 +25,12 @@ class TestApp < Rails::Application
     get "/exception", :to => "hello#exception"
     root :to => "hello#world"
   end
+
+  initializer :configure_release do
+    Raven.configure do |config|
+      config.release = 'beta'
+    end
+  end
 end
 
 class HelloController < ActionController::Base


### PR DESCRIPTION
The release can be set manually by the user. The typical way to do that would be to create an initializer:

```ruby
# config/initializers/raven.rb
Raven.configure do |config|
  config.release = ENV['RELEASE']
end
```

The hook in the Rails integration that tries to automatically detect a release is run after the app's initializers, which means it clobbers any value that has already been set - even if it can't detect a release, it sets the option back to nil.

If the user has set a release themselves, we shouldn't try to detect it.