### PR TITLE
Fix build failures on Rails 3.2 and Ruby 1.8

### DIFF
--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "rails", "~> 3.2.6"
+gem "rails", ["~> 3.2.6", "!= 3.2.22.1"]
 gem "rack-cache", "~> 1.2.0" # Ruby 1.8.7 requires this
 gem "i18n", "~> 0.6.0"
 gem "rspec"


### PR DESCRIPTION
The latest release of Rails 3.2 accidentally introduced some Ruby 1.9 hash syntax, making it incompatible with Ruby 1.8: https://github.com/rails/rails/issues/23248

It will be fixed in an upcoming release, but until then this will get the build passing again.