### PR TITLE
Makefile: version extractor tweaked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # lol
-VERSION := `cat lib/raven/version.rb | grep -e 'VERSION =' | cut -c 14- | rev | cut -c 2- | rev`
+VERSION := `cat lib/raven/version.rb | grep -e 'VERSION =' | cut -c 14- | rev | cut -c 9- | rev`
 
 test:
 	bundle install

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # lol
-VERSION := `cat lib/raven/version.rb | grep -e 'VERSION =' | cut -c 14- | rev | cut -c 9- | rev`
+VERSION := `grep '\d+\.\d+\.\d+' -o -E --color=never lib/raven/version.rb`
 
 test:
 	bundle install


### PR DESCRIPTION
:golf: 

On my system, the existing code extracted version as `0.15.4".freez`.

Here, a tweak, which outputs the `0.15.4` for the current value.

Or - Perhaps something like this?

```shell
grep 'VERSION =' lib/raven/version.rb | grep '\d+\.\d+\.\d+' -o -E --color=never
```

Which is the same as:

```shell
grep '\d+\.\d+\.\d+' -o -E --color=never lib/raven/version.rb
```