### PR TITLE
Rails 5 deprecation warning fix (Module#prepend)

### DIFF
--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -21,12 +21,18 @@ module Raven
       end
 
       if Raven.configuration.catch_debugged_exceptions
+        require 'raven/integrations/rails/middleware/debug_exceptions_catcher'
         if defined?(::ActionDispatch::DebugExceptions)
-          require 'raven/integrations/rails/middleware/debug_exceptions_catcher'
-          ::ActionDispatch::DebugExceptions.send(:include, Raven::Rails::Middleware::DebugExceptionsCatcher)
+          exceptions_class = ::ActionDispatch::DebugExceptions
         elsif defined?(::ActionDispatch::ShowExceptions)
-          require 'raven/integrations/rails/middleware/debug_exceptions_catcher'
-          ::ActionDispatch::ShowExceptions.send(:include, Raven::Rails::Middleware::DebugExceptionsCatcher)
+          exceptions_class = ::ActionDispatch::ShowExceptions
+        end
+        unless exceptions_class.nil?
+          if RUBY_VERSION.to_f < 2.0
+            exceptions_class.send(:include, Raven::Rails::Middleware::OldDebugExceptionsCatcher)
+          else
+            exceptions_class.send(:prepend, Raven::Rails::Middleware::DebugExceptionsCatcher)
+          end
         end
       end
     end

--- a/lib/raven/integrations/rails/middleware/debug_exceptions_catcher.rb
+++ b/lib/raven/integrations/rails/middleware/debug_exceptions_catcher.rb
@@ -2,6 +2,15 @@ module Raven
   class Rails
     module Middleware
       module DebugExceptionsCatcher
+        def render_exception(env_or_request, exception)
+          env = env_or_request.respond_to?(:env) ? env_or_request.env : env_or_request
+          Raven::Rack.capture_exception(exception, env)
+        ensure
+          super
+        end
+      end
+
+      module OldDebugExceptionsCatcher
         def self.included(base)
           base.send(:alias_method_chain, :render_exception, :raven)
         end


### PR DESCRIPTION
Remove the deprecation warning, WITH legacy support :pray:
```
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super.
```
