### PR TITLE
Don't check `catch_debugged_exceptions` setting before user has set it

### DIFF
--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -19,7 +19,9 @@ module Raven
         config.project_root ||= ::Rails.root
         config.release = config.detect_release # if project_root has changed, need to re-check
       end
+    end
 
+    config.after_initialize do
       if Raven.configuration.catch_debugged_exceptions
         require 'raven/integrations/rails/middleware/debug_exceptions_catcher'
         if defined?(::ActionDispatch::DebugExceptions)


### PR DESCRIPTION
Looks like a side effect of https://github.com/getsentry/raven-ruby/pull/450 was to remove the usefulness of the `catch_debugged_exceptions` setting. Checking this setting obviously need to be done *after* it's set.