### PR TITLE
Check catch_debugged_exceptions option at runtime

### DIFF
--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -22,19 +22,17 @@ module Raven
     end
 
     config.after_initialize do
-      if Raven.configuration.catch_debugged_exceptions
-        require 'raven/integrations/rails/middleware/debug_exceptions_catcher'
-        if defined?(::ActionDispatch::DebugExceptions)
-          exceptions_class = ::ActionDispatch::DebugExceptions
-        elsif defined?(::ActionDispatch::ShowExceptions)
-          exceptions_class = ::ActionDispatch::ShowExceptions
-        end
-        unless exceptions_class.nil?
-          if RUBY_VERSION.to_f < 2.0
-            exceptions_class.send(:include, Raven::Rails::Middleware::OldDebugExceptionsCatcher)
-          else
-            exceptions_class.send(:prepend, Raven::Rails::Middleware::DebugExceptionsCatcher)
-          end
+      require 'raven/integrations/rails/middleware/debug_exceptions_catcher'
+      if defined?(::ActionDispatch::DebugExceptions)
+        exceptions_class = ::ActionDispatch::DebugExceptions
+      elsif defined?(::ActionDispatch::ShowExceptions)
+        exceptions_class = ::ActionDispatch::ShowExceptions
+      end
+      unless exceptions_class.nil?
+        if RUBY_VERSION.to_f < 2.0
+          exceptions_class.send(:include, Raven::Rails::Middleware::OldDebugExceptionsCatcher)
+        else
+          exceptions_class.send(:prepend, Raven::Rails::Middleware::DebugExceptionsCatcher)
         end
       end
     end

--- a/lib/raven/integrations/rails/middleware/debug_exceptions_catcher.rb
+++ b/lib/raven/integrations/rails/middleware/debug_exceptions_catcher.rb
@@ -5,7 +5,7 @@ module Raven
         def render_exception(env_or_request, exception)
           begin
             env = env_or_request.respond_to?(:env) ? env_or_request.env : env_or_request
-            Raven::Rack.capture_exception(exception, env)
+            Raven::Rack.capture_exception(exception, env) if Raven.configuration.catch_debugged_exceptions
           rescue # rubocop:disable Lint/HandleExceptions
           end
           super
@@ -20,7 +20,7 @@ module Raven
         def render_exception_with_raven(env_or_request, exception)
           begin
             env = env_or_request.respond_to?(:env) ? env_or_request.env : env_or_request
-            Raven::Rack.capture_exception(exception, env)
+            Raven::Rack.capture_exception(exception, env) if Raven.configuration.catch_debugged_exceptions
           rescue # rubocop:disable Lint/HandleExceptions
           end
           render_exception_without_raven(env_or_request, exception)

--- a/spec/raven/integrations/rails/middleware/debug_exceptions_catcher_spec.rb
+++ b/spec/raven/integrations/rails/middleware/debug_exceptions_catcher_spec.rb
@@ -26,11 +26,7 @@ describe Raven::Rails::Middleware::DebugExceptionsCatcher do
 
   let(:env) { {} }
 
-  context "using include" do
-    before do
-      middleware.send(:include, Raven::Rails::Middleware::OldDebugExceptionsCatcher)
-    end
-
+  shared_examples "the debug exceptions middleware" do
     it "shows the exception" do
       expect(middleware.new(app).call(env)).to eq([500, "app error", {}])
     end
@@ -46,6 +42,33 @@ describe Raven::Rails::Middleware::DebugExceptionsCatcher do
         expect(middleware.new(app).call(env)).to eq([500, "app error", {}])
       end
     end
+
+    context "when catch_debugged_exceptions is disabled" do
+      before do
+        Raven.configure do |config|
+          config.catch_debugged_exceptions = false
+        end
+      end
+
+      after do
+        Raven.configure do |config|
+          config.catch_debugged_exceptions = true
+        end
+      end
+
+      it "doesn't capture the exception" do
+        expect(Raven::Rack).not_to receive(:capture_exception)
+        middleware.new(app).call(env)
+      end
+    end
+  end
+
+  context "using include" do
+    before do
+      middleware.send(:include, Raven::Rails::Middleware::OldDebugExceptionsCatcher)
+    end
+
+    it_behaves_like "the debug exceptions middleware"
   end
 
   context "using prepend" do
@@ -54,20 +77,6 @@ describe Raven::Rails::Middleware::DebugExceptionsCatcher do
       middleware.send(:prepend, Raven::Rails::Middleware::DebugExceptionsCatcher)
     end
 
-    it "shows the exception" do
-      expect(middleware.new(app).call(env)).to eq([500, "app error", {}])
-    end
-
-    it "captures the exception" do
-      expect(Raven::Rack).to receive(:capture_exception)
-      middleware.new(app).call(env)
-    end
-
-    context "when an error is raised" do
-      it "shows the original exception" do
-        allow(Raven::Rack).to receive(:capture_exception).and_raise("raven error")
-        expect(middleware.new(app).call(env)).to eq([500, "app error", {}])
-      end
-    end
+    it_behaves_like "the debug exceptions middleware"
   end
 end

--- a/spec/raven/integrations/rails_spec.rb
+++ b/spec/raven/integrations/rails_spec.rb
@@ -48,4 +48,24 @@ describe TestApp, :type => :request do
   it "doesn't clobber a manually configured release" do
     expect(Raven.configuration.release).to eq('beta')
   end
+
+  context "when catch_debugged_exceptions is disabled" do
+    before do
+      Raven.configure do |config|
+        config.catch_debugged_exceptions = false
+      end
+    end
+
+    after do
+      Raven.configure do |config|
+        config.catch_debugged_exceptions = true
+      end
+    end
+
+    it "doesn't capture exceptions automatically" do
+      get "/exception"
+      expect(response.status).to eq(500)
+      expect(Raven.client.transport.events.size).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Instead of adding the hook to report debugged exceptions based on the value of the configuration option while Rails is initialising, we can always add the hook, but have it check the option at runtime. This is more in line with how other configuration options are used, and means that the option can be set or changed at any time, which would have prevented #458.

This also lets us write tests that exercise this behaviour, since the logic is no longer tied to the Rails initialisation process, which can only happen once during the test suite.