### PR TITLE
Fix docs, `user_context` example parameters in Rails

### DIFF
--- a/docs/integrations/rails.rst
+++ b/docs/integrations/rails.rst
@@ -48,7 +48,7 @@ Params and sessions
     private
 
     def set_raven_context
-      Raven.user_context(user_id: session[:current_user_id]) # or anything else in session
+      Raven.user_context(id: session[:current_user_id]) # or anything else in session
       Raven.extra_context(params: params.to_hash, url: request.url)
     end
   end


### PR DESCRIPTION
`user_id` should be `id`.