### PR TITLE
Use OldDebugExceptionsCatcher on jRuby

### DIFF
--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -30,7 +30,7 @@ module Raven
           exceptions_class = ::ActionDispatch::ShowExceptions
         end
         unless exceptions_class.nil?
-          if RUBY_VERSION.to_f < 2.0
+          if RUBY_VERSION.to_f < 2.0 || RUBY_PLATFORM == 'java'
             exceptions_class.send(:include, Raven::Rails::Middleware::OldDebugExceptionsCatcher)
           else
             exceptions_class.send(:prepend, Raven::Rails::Middleware::DebugExceptionsCatcher)


### PR DESCRIPTION
I just experienced this one on jruby-1.7.19

```
NoMethodError: undefined method `prepend' for ActionDispatch::DebugExceptions:Class
                                   Rails at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/sentry-raven-0.15.6/lib/raven/integrations/rails.rb:36
                                    call at org/jruby/RubyProc.java:271
                            execute_hook at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/activesupport-4.1.10/lib/active_support/lazy_load_hooks.rb:36
                          run_load_hooks at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/activesupport-4.1.10/lib/active_support/lazy_load_hooks.rb:45
                                    each at org/jruby/RubyArray.java:1613
                          run_load_hooks at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/activesupport-4.1.10/lib/active_support/lazy_load_hooks.rb:44
                                Finisher at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/railties-4.1.10/lib/rails/application/finisher.rb:64
                           instance_exec at org/jruby/RubyBasicObject.java:1562
                                     run at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/railties-4.1.10/lib/rails/initializable.rb:30
                        run_initializers at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/railties-4.1.10/lib/rails/initializable.rb:55
                              tsort_each at /home/ubuntu/.rvm/rubies/jruby-1.7.19/lib/ruby/1.9/tsort.rb:150
       each_strongly_connected_component at /home/ubuntu/.rvm/rubies/jruby-1.7.19/lib/ruby/1.9/tsort.rb:183
  each_strongly_connected_component_from at /home/ubuntu/.rvm/rubies/jruby-1.7.19/lib/ruby/1.9/tsort.rb:219
       each_strongly_connected_component at /home/ubuntu/.rvm/rubies/jruby-1.7.19/lib/ruby/1.9/tsort.rb:182
                                    each at org/jruby/RubyArray.java:1613
       each_strongly_connected_component at /home/ubuntu/.rvm/rubies/jruby-1.7.19/lib/ruby/1.9/tsort.rb:180
                              tsort_each at /home/ubuntu/.rvm/rubies/jruby-1.7.19/lib/ruby/1.9/tsort.rb:148
                        run_initializers at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/railties-4.1.10/lib/rails/initializable.rb:54
                             initialize! at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/railties-4.1.10/lib/rails/application.rb:300
                                  (root) at /home/ubuntu/smelending/config/environment.rb:6
                                 require at org/jruby/RubyKernel.java:1071
                                  (root) at /home/ubuntu/smelending/test/test_helper.rb:1
                                 require at org/jruby/RubyKernel.java:1071
                                  (root) at /home/ubuntu/smelending/test/test_helper.rb:3
                                 require at org/jruby/RubyKernel.java:1071
                                  (root) at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:10
                                    each at org/jruby/RubyArray.java:1613
                                  (root) at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:9
                                  select at org/jruby/RubyArray.java:2468
                                  (root) at /home/ubuntu/smelending/vendor/bundle/jruby/1.9/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:4
D, [2016-03-10T22:36:21.483000 #19635] DEBUG -- : ** [Raven] Event not sent due to excluded environment: test
rake aborted!
SignalException: 1

Tasks: TOP => test

(See full trace by running task with --trace) ((bundle exec "rake test")) returned exit code 1
```


