### PR TITLE
Optimizations

### DIFF
--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -74,7 +74,7 @@ module Raven
 
     def encode(event)
       hash = @processors.reduce(event.to_hash) { |memo, p| p.process(memo) }
-      encoded = OkJson.encode(hash)
+      encoded = configuration.json_class.encode(hash)
 
       case configuration.encoding
       when 'gzip'

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -63,6 +63,40 @@ module Raven
 
     private
 
+    def process_event(hash)
+      # Optimizations to disable stack trace processing aren't enabled, just run it all through
+      if configuration.sanitize_internal_data || !hash[:exception] || !hash[:exception][:values]
+        return @processors.reduce(hash) { |memo, p| p.process(memo) }
+      end
+
+      # Strip out modules
+      modules = hash.delete(:modules)
+
+      # Strip out the stacktrace from the hash
+      stacktraces = {}
+      hash[:exception][:values].each_with_index do |exc, index|
+        stacktraces[index] = exc.delete(:stacktrace)
+        # Store the index ID just in case any of the processors reorganize or generally mess with things
+        exc[:_trace_id] = index
+      end
+
+      # Sanitize everything
+      @processors.each do |processor|
+        hash = processor.process(hash)
+      end
+
+      # Restore the stacktraces
+      hash[:exception][:values].each do |exc|
+        exc[:stacktrace] = stacktraces[exc.delete(:_trace_id)]
+      end
+
+      # Restore the modules
+      hash[:modules] = modules if modules
+
+      # Return sanitized
+      hash
+    end
+
     def configuration_allows_sending
       if configuration.send_in_current_environment?
         true
@@ -73,8 +107,7 @@ module Raven
     end
 
     def encode(event)
-      hash = @processors.reduce(event.to_hash) { |memo, p| p.process(memo) }
-      encoded = configuration.json_class.encode(hash)
+      encoded = configuration.json_class.encode(process_event(event.to_hash))
 
       case configuration.encoding
       when 'gzip'

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -102,6 +102,9 @@ module Raven
     # Sanitize values that look like credit card numbers
     attr_accessor :sanitize_credit_cards
 
+    # Sanitize data within a stacktrace frames (paths, functions, filenames) and modules (gems used)
+    attr_accessor :sanitize_internal_data
+
     # JSON serializer/deserializer to use
     attr_accessor :json_class
 
@@ -141,6 +144,7 @@ module Raven
       self.catch_debugged_exceptions = true
       self.sanitize_fields = []
       self.sanitize_credit_cards = true
+      self.sanitize_internal_data = true
       self.environments = []
       self.json_class = OkJson
 

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -102,6 +102,9 @@ module Raven
     # Sanitize values that look like credit card numbers
     attr_accessor :sanitize_credit_cards
 
+    # JSON serializer/deserializer to use
+    attr_accessor :json_class
+
     IGNORE_DEFAULT = [
       'AbstractController::ActionNotFound',
       'ActionController::InvalidAuthenticityToken',
@@ -139,6 +142,7 @@ module Raven
       self.sanitize_fields = []
       self.sanitize_credit_cards = true
       self.environments = []
+      self.json_class = OkJson
 
       self.release = detect_release
     end

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -145,6 +145,10 @@ module Raven
       self.json_class = OkJson
 
       self.release = detect_release
+
+      # Try to resolve the hostname to an FQDN, but fall back to whatever the load name is
+      self.server_name = Socket.gethostname
+      self.server_name = Socket.gethostbyname(hostname).first rescue server_name
     end
 
     def server=(value)

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -192,20 +192,23 @@ module Raven
 
     def self.stacktrace_interface_from(int, evt, backtrace)
       backtrace = Backtrace.parse(backtrace)
-      int.frames = backtrace.lines.reverse.map do |line|
-        StacktraceInterface::Frame.new.tap do |frame|
-          frame.abs_path = line.file if line.file
-          frame.function = line.method if line.method
-          frame.lineno = line.number
-          frame.in_app = line.in_app
-          frame.module = line.module_name if line.module_name
 
-          if evt.configuration[:context_lines] && frame.abs_path
-            frame.pre_context, frame.context_line, frame.post_context = \
-              evt.get_file_context(frame.abs_path, frame.lineno, evt.configuration[:context_lines])
-          end
+      int.frames = []
+      backtrace.lines.reverse_each do |line|
+        frame = StacktraceInterface::Frame.new
+        frame.abs_path = line.file if line.file
+        frame.function = line.method if line.method
+        frame.lineno = line.number
+        frame.in_app = line.in_app
+        frame.module = line.module_name if line.module_name
+
+        if evt.configuration[:context_lines] && frame.abs_path
+          frame.pre_context, frame.context_line, frame.post_context = \
+            evt.get_file_context(frame.abs_path, frame.lineno, evt.configuration[:context_lines])
         end
-      end.select(&:filename)
+
+        int.frames << frame if frame.filename
+      end
 
       evt.culprit = evt.get_culprit(int.frames)
     end

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -40,7 +40,7 @@ module Raven
       @level         = :error
       @logger        = ''
       @culprit       = nil
-      @server_name   = @configuration.server_name || resolve_hostname
+      @server_name   = @configuration.server_name
       @release       = @configuration.release
       @modules       = list_gem_specs if @configuration.send_modules
       @user          = {}
@@ -67,12 +67,6 @@ module Raven
       @timestamp  = @timestamp.strftime('%Y-%m-%dT%H:%M:%S') if @timestamp.is_a?(Time)
       @time_spent = (@time_spent*1000).to_i if @time_spent.is_a?(Float)
       @level      = LOG_LEVELS[@level.to_s.downcase] if @level.is_a?(String) || @level.is_a?(Symbol)
-    end
-
-    def resolve_hostname
-      # Try to resolve the hostname to an FQDN, but fall back to whatever the load name is
-      hostname = Socket.gethostname
-      Socket.gethostbyname(hostname).first rescue hostname
     end
 
     def list_gem_specs

--- a/lib/raven/okjson.rb
+++ b/lib/raven/okjson.rb
@@ -30,8 +30,12 @@ require 'stringio'
 module Raven
 module OkJson
   Upstream = '43'
+
   extend self
 
+  def error_class
+    Error
+  end
 
   # Decodes a json document in string s and
   # returns the corresponding ruby value.

--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -72,8 +72,8 @@ module Raven
 
     def parse_json_or_nil(string)
       begin
-        OkJson.decode(string)
-      rescue Raven::OkJson::Error, NoMethodError
+        Raven.configuration.json_class.decode(string)
+      rescue Raven.configuration.json_class.error_class, NoMethodError
         nil
       end
     end

--- a/lib/raven/ruby_json.rb
+++ b/lib/raven/ruby_json.rb
@@ -1,0 +1,15 @@
+module Raven
+  module RubyJson
+    def self.error_class
+      JSON::JSONError
+    end
+
+    def self.encode(data)
+      JSON.generate(data)
+    end
+
+    def self.decode(str)
+      JSON.parse(str)
+    end
+  end
+end

--- a/spec/raven/client_spec.rb
+++ b/spec/raven/client_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe Raven::Client do
+  let(:config) { Raven::Configuration.new }
+  let(:instance) { Raven::Client.new(config) }
+
+  context '.process_event' do
+    let(:dummy_processor) { instance_double("Raven::Processor") }
+    let(:exc_hash) do
+      {
+        :foo => 'bar',
+        :modules => {
+          'rails' => '1.0.0',
+          'raven-ruby' => '1.0.5'
+        },
+        :exception => {
+          :values => [
+            { :name => 'first', :stacktrace => %w(a b c) },
+            { :name => 'second', :stacktrace => %w(d e f) },
+            { :name => 'third', :stacktrace => %w(x y z) }
+          ]
+        }
+      }
+    end
+
+    before { config.processors = [double(:new => dummy_processor)] }
+
+    context 'by default' do
+      it 'sanitizes all data' do
+        expect(dummy_processor).to receive(:process).with(exc_hash).and_return('processed')
+        expect(instance.send(:process_event, exc_hash)).to eq('processed')
+      end
+    end
+
+    context 'with internal data sanitization disabled' do
+      let(:filtered_hash) do
+        {
+          :foo => 'bar',
+          :exception => {
+            :values => [
+              { :name => 'first' },
+              { :name => 'second' },
+              { :name => 'third' }
+            ]
+          }
+        }
+      end
+
+      before { config.sanitize_internal_data = false }
+
+      it 'does not sanitize modules and exceptions' do
+        # Confirm we're sanitizing it properly
+        expect(dummy_processor).to receive(:process) do |hash|
+          expect(hash[:modules]).to eq(nil)
+
+          hash[:exception][:values].each do |row|
+            expect(row[:_trace_id]).to_not eq(nil)
+            expect(row[:stacktrace]).to eq(nil)
+          end
+
+          hash.merge(:_filtered => 1)
+        end
+
+        result = instance.send(:process_event, exc_hash.dup)
+        # Make sure we sent it through the procsesor and care about the response
+        expect(result.delete(:_filtered)).to eq(1)
+        # Confirm we properly restored the modules/stacktrace
+        expect(result).to eq(exc_hash)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey, we were noticing some performance issues with the Raven gem. I dug in and optimization a bunch of the major hotspots I found. All numbers below are base vs optimization, rather than cumulative of all optimizations done.

I added an option to use `JSON` instead of `OkJson`. `JSON` has a native C client which is much much faster. This was a 35% improvement.

Each `Backtrace::Line` instance would cache `in_app_pattern` regex. Since nothing in that regex relies on the line data, I moved it to be cached by the `Backtrace` class instead. That was 10%.

The `modules` and `stacktrace` portions of the event are all internal data that doesn't need to be redacted normally. I added an option to let people disable redaction, as those are the biggest parts of the event hash. This was a 52% improvement.

Those were the big ones, I did two smaller optimizations since they were easy. Calling `resolve_hostname` per exception is a little excessive, I moved it to be called when `Raven::Configuration` is initialized. I also did a small optimization to `stacktrace_interface_from` by reducing the amount of lines it needed to iterate over.


```
                    user     system      total        real
base   3.820000   0.040000   3.860000 (  3.974137)

                    user     system      total        real
optimizations   0.360000   0.000000   0.360000 (  0.365436)
```

RubyProf traces on Ruby 2.3.0, against the latest Raven master: [pre-optimization](https://gist.github.com/zanker/683c9346af06453a8b14), [post-optimization](https://gist.github.com/zanker/5278a25a2904f7542150).

In general, I tried to preserve the existing functionality and make the improvements be optional to avoid breaking anything.

cc @nerdrew