### PR TITLE
Prevent exception duplication in chain

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -163,12 +163,11 @@ module Raven
         exceptions = [exc]
         context = Set.new [exc.object_id]
         while exc.respond_to?(:cause) && exc.cause
-          exceptions << exc.cause
           exc = exc.cause
-          # TODO(dcramer): ideally this would log to inform the user
           if context.include?(exc.object_id)
             break
           end
+          exceptions << exc
           context.add(exc.object_id)
         end
         exceptions.reverse!


### PR DESCRIPTION
We would previously show it twice since even if it was already present in the context it was still being added to the exceptions array.