### PR TITLE
Allow for bypassing the proxy

### DIFF
--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -48,6 +48,7 @@ module Raven
         conn.headers[:user_agent] = "sentry-ruby/#{Raven::VERSION}"
 
         conn.options[:proxy] = configuration.proxy if configuration.proxy
+        conn.options[:proxy] = nil if configuration.proxy == false #false disables the proxy
         conn.options[:timeout] = configuration.timeout if configuration.timeout
         conn.options[:open_timeout] = configuration.open_timeout if configuration.open_timeout
 


### PR DESCRIPTION
Faraday by default picks up the proxy from `http_proxy` environment variable. This allows to explicitly bypass the proxy. This is useful in `on-premise` sentry scenarios where a proxy is needed to access other resources on the internet.

