### PR TITLE
Skip identical backtraces from "re-raised" exceptions

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -127,6 +127,7 @@ module Raven
         evt.interface(:exception) do |exc_int|
           exceptions = [exc]
           context = Set.new [exc.object_id]
+          backtraces = Set.new
 
           while exc.respond_to?(:cause) && exc.cause
             exc = exc.cause
@@ -145,7 +146,8 @@ module Raven
               int.module = e.class.to_s.split('::')[0...-1].join('::')
 
               int.stacktrace =
-                if e.backtrace
+                if e.backtrace && !backtraces.include?(e.backtrace.object_id)
+                  backtraces << e.backtrace.object_id
                   StacktraceInterface.new do |stacktrace|
                     stacktrace_interface_from(stacktrace, evt, e.backtrace)
                   end


### PR DESCRIPTION
Using sentry in a rails application I noticed that recorded exception contain a lot of duplicated backtraces blowing up the submitted JSON unnecessary.

This happens because in the great big rails onion there are a lot of places where exception are rewrapped preserving the backtrace.
E.g. all errors in views get wrapped in an [ActionView::Template::Error](https://github.com/rails/rails/blob/master/actionview/lib/action_view/template/error.rb#L72)

Depending on used gems and middleware the JSON payload gets quite big.
I'm seeing reported exceptions with 300KB of json containing 9 exceptions but only three distinct stacktraces.

I'm not sure if this PR is the best solution for tackling this but I wanted to have this elicit some feedback on how this could be improved.