### PR TITLE
Pass event id to Rack env

### DIFF
--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -25,11 +25,13 @@ module Raven
       if env['raven.requested_at']
         options[:time_spent] = Time.now - env['raven.requested_at']
       end
-      Raven.capture_type(exception, options) do |evt|
+      event = Raven.capture_type(exception, options) do |evt|
         evt.interface :http do |int|
           int.from_rack(env)
         end
       end
+
+      env['sentry-event-id'] = event.id
     end
     class << self
       alias capture_message capture_type

--- a/spec/raven/integrations/rack_spec.rb
+++ b/spec/raven/integrations/rack_spec.rb
@@ -94,4 +94,15 @@ describe Raven::Rack do
     stack = Raven::Rack.new(Rack::Lint.new(app))
     expect { stack.call(env) }.to_not raise_error
   end
+
+  it 'should pass event id to env' do
+    env = {}
+    exception = build_exception
+    app = lambda { |_e| raise exception }
+
+    stack = Raven::Rack.new(app)
+
+    expect { stack.call(env) }.to raise_error
+    expect(env).to include('sentry-event-id')
+  end
 end


### PR DESCRIPTION
Record last event id to Rack's env so that it can be used in later stages of request.