### PR TITLE
Extract Raven::Instance and delegate from Raven to it

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,6 +11,7 @@
 Lint/RescueException:
   Exclude:
     - 'lib/raven/base.rb'
+    - 'lib/raven/instance.rb'
     - 'lib/raven/integrations/delayed_job.rb'
     - 'lib/raven/integrations/rack.rb'
     - 'lib/raven/integrations/sidekiq.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -206,7 +206,6 @@ Style/HashSyntax:
 # Configuration parameters: MaxLineLength.
 Style/IfUnlessModifier:
   Exclude:
-    - 'lib/raven/base.rb'
     - 'lib/raven/event.rb'
     - 'lib/raven/interfaces/exception.rb'
     - 'lib/raven/interfaces/single_exception.rb'

--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -17,187 +17,33 @@ require 'raven/interfaces/single_exception'
 require 'raven/interfaces/stack_trace'
 require 'raven/interfaces/http'
 require 'raven/utils/deep_merge'
+require 'raven/instance'
+
+require 'forwardable'
 
 module Raven
   AVAILABLE_INTEGRATIONS = %w[delayed_job railties sidekiq rack rake].freeze
 
   class << self
-    # The client object is responsible for delivering formatted data to the Sentry server.
-    # Must respond to #send. See Raven::Client.
-    attr_writer :client
+    extend Forwardable
 
-    # A Raven configuration object. Must act like a hash and return sensible
-    # values for all Raven configuration options. See Raven::Configuration.
-    attr_writer :configuration
-
-    def context
-      Context.current
+    def instance
+      @instance ||= Raven::Instance.new
     end
 
-    def logger
-      @logger ||= Logger.new
-    end
+    def_delegators :instance, :client=, :configuration=, :context, :logger, :configuration,
+                   :client, :report_status, :configure, :send_event, :capture, :capture_type,
+                   :last_event_id, :should_capture?, :annotate_exception, :user_context,
+                   :tags_context, :extra_context, :rack_context
 
-    # The configuration object.
-    # @see Raven.configure
-    def configuration
-      @configuration ||= Configuration.new
-    end
-
-    # The client object is responsible for delivering formatted data to the Sentry server.
-    def client
-      @client ||= Client.new(configuration)
-    end
-
-    # Tell the log that the client is good to go
-    def report_status
-      return if client.configuration.silence_ready
-      if client.configuration.send_in_current_environment?
-        logger.info "Raven #{VERSION} ready to catch errors"
-      else
-        logger.info "Raven #{VERSION} configured not to send errors."
-      end
-    end
-    alias_method :report_ready, :report_status
-
-    # Call this method to modify defaults in your initializers.
-    #
-    # @example
-    #   Raven.configure do |config|
-    #     config.server = 'http://...'
-    #   end
-    def configure
-      yield(configuration) if block_given?
-
-      self.client = Client.new(configuration)
-      report_status
-      self.client
-    end
-
-    # Send an event to the configured Sentry server
-    #
-    # @example
-    #   evt = Raven::Event.new(:message => "An error")
-    #   Raven.send_event(evt)
-    def send_event(event)
-      client.send_event(event)
-    end
-
-    # Capture and process any exceptions from the given block, or globally if
-    # no block is given
-    #
-    # @example
-    #   Raven.capture do
-    #     MyApp.run
-    #   end
-    def capture(options = {})
-      if block_given?
-        begin
-          yield
-        rescue Error
-          raise # Don't capture Raven errors
-        rescue Exception => e
-          capture_exception(e, options)
-          raise
-        end
-      else
-        install_at_exit_hook(options)
-      end
-    end
-
-    def capture_type(obj, options = {})
-      return false unless should_capture?(obj)
-      message_or_exc = obj.is_a?(String) ? "message" : "exception"
-      if (evt = Event.send("from_" + message_or_exc, obj, options))
-        yield evt if block_given?
-        if configuration.async?
-          configuration.async.call(evt)
-        else
-          send_event(evt)
-        end
-        Thread.current[:sentry_last_event_id] = evt.id
-        evt
-      end
-    end
-    alias_method :capture_message, :capture_type
-    alias_method :capture_exception, :capture_type
-
-    def last_event_id
-      Thread.current[:sentry_last_event_id]
-    end
-
-    def should_capture?(message_or_exc)
-      if configuration.should_capture
-        configuration.should_capture.call(*[message_or_exc])
-      else
-        true
-      end
-    end
-
-    # Provides extra context to the exception prior to it being handled by
-    # Raven. An exception can have multiple annotations, which are merged
-    # together.
-    #
-    # The options (annotation) is treated the same as the ``options``
-    # parameter to ``capture_exception`` or ``Event.from_exception``, and
-    # can contain the same ``:user``, ``:tags``, etc. options as these
-    # methods.
-    #
-    # These will be merged with the ``options`` parameter to
-    # ``Event.from_exception`` at the top of execution.
-    #
-    # @example
-    #   begin
-    #     raise "Hello"
-    #   rescue => exc
-    #     Raven.annotate_exception(exc, :user => { 'id' => 1,
-    #                              'email' => 'foo@example.com' })
-    #   end
-    def annotate_exception(exc, options = {})
-      notes = (exc.instance_variable_defined?(:@__raven_context) && exc.instance_variable_get(:@__raven_context)) || {}
-      notes.merge!(options)
-      exc.instance_variable_set(:@__raven_context, notes)
-      exc
-    end
-
-    # Bind user context. Merges with existing context (if any).
-    #
-    # It is recommending that you send at least the ``id`` and ``email``
-    # values. All other values are arbitrary.
-    #
-    # @example
-    #   Raven.user_context('id' => 1, 'email' => 'foo@example.com')
-    def user_context(options = nil)
-      self.context.user = options || {}
-    end
-
-    # Bind tags context. Merges with existing context (if any).
-    #
-    # Tags are key / value pairs which generally represent things like application version,
-    # environment, role, and server names.
-    #
-    # @example
-    #   Raven.tags_context('my_custom_tag' => 'tag_value')
-    def tags_context(options = nil)
-      self.context.tags.merge!(options || {})
-    end
-
-    # Bind extra context. Merges with existing context (if any).
-    #
-    # Extra context shows up as Additional Data within Sentry, and is completely arbitrary.
-    #
-    # @example
-    #   Raven.extra_context('my_custom_data' => 'value')
-    def extra_context(options = nil)
-      self.context.extra.merge!(options || {})
-    end
-
-    def rack_context(env)
-      if env.empty?
-        env = nil
-      end
-      self.context.rack_env = env
-    end
+    def_delegator :instance, :report_status, :report_ready
+    def_delegator :instance, :capture_type, :capture_message
+    def_delegator :instance, :capture_type, :capture_exception
+    # For cross-language compatibility
+    def_delegator :instance, :capture_type, :captureException
+    def_delegator :instance, :capture_type, :captureMessage
+    def_delegator :instance, :annotate_exception, :annotateException
+    def_delegator :instance, :annotate_exception, :annotate
 
     # Injects various integrations. Default behavior: inject all available integrations
     def inject
@@ -240,12 +86,6 @@ module Raven
         opts[:to].send(:include, Raven::Rails::Overrides.const_get("Old" + module_name))
       end
     end
-
-    # For cross-language compat
-    alias :captureException :capture_exception
-    alias :captureMessage :capture_message
-    alias :annotateException :annotate_exception
-    alias :annotate :annotate_exception
 
     private
 

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -1,0 +1,203 @@
+require 'raven/base'
+
+module Raven
+  # A copy of Raven's base module class methods, minus some of the integration
+  # and global hooks since it's meant to be used explicitly. Useful for
+  # sending errors to multiple sentry projects in a large application.
+  #
+  # @example
+  #   class Foo
+  #     def initialize
+  #       @other_raven = Raven::Instance.new
+  #       @other_raven.configure do |config|
+  #         config.server = 'http://...'
+  #       end
+  #     end
+  #
+  #     def foo
+  #       # ...
+  #     rescue => e
+  #       @other_raven.capture_exception(e)
+  #     end
+  #   end
+  class Instance
+    # The client object is responsible for delivering formatted data to the
+    # Sentry server. Must respond to #send. See Raven::Client.
+    attr_writer :client
+
+    # A Raven configuration object. Must act like a hash and return sensible
+    # values for all Raven configuration options. See Raven::Configuration.
+    attr_writer :configuration
+
+    def context
+      @context ||= Context.new
+    end
+
+    def logger
+      @logger ||= Logger.new
+    end
+
+    # The configuration object.
+    # @see Raven.configure
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    # The client object is responsible for delivering formatted data to the
+    # Sentry server.
+    def client
+      @client ||= Client.new(configuration)
+    end
+
+    # Tell the log that the client is good to go
+    def report_status
+      return if client.configuration.silence_ready
+      if client.configuration.send_in_current_environment?
+        logger.info "Raven #{VERSION} ready to catch errors"
+      else
+        logger.info "Raven #{VERSION} configured not to send errors."
+      end
+    end
+    alias_method :report_ready, :report_status
+
+    # Call this method to modify defaults in your initializers.
+    #
+    # @example
+    #   Raven.configure do |config|
+    #     config.server = 'http://...'
+    #   end
+    def configure
+      yield(configuration) if block_given?
+
+      self.client = Client.new(configuration)
+      report_status
+      self.client
+    end
+
+    # Send an event to the configured Sentry server
+    #
+    # @example
+    #   evt = Raven::Event.new(:message => "An error")
+    #   Raven.send_event(evt)
+    def send_event(event)
+      client.send_event(event)
+    end
+
+    # Capture and process any exceptions from the given block.
+    #
+    # @example
+    #   Raven.capture do
+    #     MyApp.run
+    #   end
+    def capture(options = {})
+      begin
+        yield
+      rescue Error
+        raise # Don't capture Raven errors
+      rescue Exception => e
+        capture_exception(e, options)
+        raise
+      end
+    end
+
+    def capture_type(obj, options = {})
+      return false unless should_capture?(obj)
+      message_or_exc = obj.is_a?(String) ? "message" : "exception"
+      if (evt = Event.send("from_" + message_or_exc, obj, options))
+        yield evt if block_given?
+        if configuration.async?
+          configuration.async.call(evt)
+        else
+          send_event(evt)
+        end
+        Thread.current["sentry_#{object_id}_last_event_id".to_sym] = evt.id
+        evt
+      end
+    end
+    alias_method :capture_message, :capture_type
+    alias_method :capture_exception, :capture_type
+
+    def last_event_id
+      Thread.current["sentry_#{object_id}_last_event_id".to_sym]
+    end
+
+    def should_capture?(message_or_exc)
+      if configuration.should_capture
+        configuration.should_capture.call(*[message_or_exc])
+      else
+        true
+      end
+    end
+
+    # Provides extra context to the exception prior to it being handled by
+    # Raven. An exception can have multiple annotations, which are merged
+    # together.
+    #
+    # The options (annotation) is treated the same as the ``options``
+    # parameter to ``capture_exception`` or ``Event.from_exception``, and
+    # can contain the same ``:user``, ``:tags``, etc. options as these
+    # methods.
+    #
+    # These will be merged with the ``options`` parameter to
+    # ``Event.from_exception`` at the top of execution.
+    #
+    # @example
+    #   begin
+    #     raise "Hello"
+    #   rescue => exc
+    #     Raven.annotate_exception(exc, :user => { 'id' => 1,
+    #                              'email' => 'foo@example.com' })
+    #   end
+    def annotate_exception(exc, options = {})
+      notes = (exc.instance_variable_defined?(:@__raven_context) && exc.instance_variable_get(:@__raven_context)) || {}
+      notes.merge!(options)
+      exc.instance_variable_set(:@__raven_context, notes)
+      exc
+    end
+
+    # Bind user context. Merges with existing context (if any).
+    #
+    # It is recommending that you send at least the ``id`` and ``email``
+    # values. All other values are arbitrary.
+    #
+    # @example
+    #   Raven.user_context('id' => 1, 'email' => 'foo@example.com')
+    def user_context(options = nil)
+      context.user = options || {}
+    end
+
+    # Bind tags context. Merges with existing context (if any).
+    #
+    # Tags are key / value pairs which generally represent things like
+    # application version, environment, role, and server names.
+    #
+    # @example
+    #   Raven.tags_context('my_custom_tag' => 'tag_value')
+    def tags_context(options = nil)
+      context.tags.merge!(options || {})
+    end
+
+    # Bind extra context. Merges with existing context (if any).
+    #
+    # Extra context shows up as Additional Data within Sentry, and is
+    # completely arbitrary.
+    #
+    # @example
+    #   Raven.extra_context('my_custom_data' => 'value')
+    def extra_context(options = nil)
+      context.extra.merge!(options || {})
+    end
+
+    def rack_context(env)
+      env = nil if env.empty?
+
+      context.rack_env = env
+    end
+
+    # For cross-language compat
+    alias :captureException :capture_exception
+    alias :captureMessage :capture_message
+    alias :annotateException :annotate_exception
+    alias :annotate :annotate_exception
+  end
+end

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -1,0 +1,185 @@
+require 'spec_helper'
+require 'raven/instance'
+
+describe Raven::Instance do
+  let(:event) { double("event", :id => "event_id") }
+  let(:options) { double("options") }
+
+  subject { described_class.new }
+
+  before do
+    allow(subject).to receive(:send_event)
+    allow(Raven::Event).to receive(:from_message) { event }
+    allow(Raven::Event).to receive(:from_exception) { event }
+  end
+
+  describe '#context' do
+    it 'is different than Raven.context'
+  end
+
+  describe '#capture_message' do
+    let(:message) { "Test message" }
+
+    it 'sends the result of Event.capture_message' do
+      expect(Raven::Event).to receive(:from_message).with(message, options)
+      expect(subject).to receive(:send_event).with(event)
+
+      subject.capture_message(message, options)
+    end
+
+    it 'yields the event to a passed block' do
+      expect { |b| subject.capture_message(message, options, &b) }.to yield_with_args(event)
+    end
+  end
+
+  describe '#capture_message when async' do
+    let(:message) { "Test message" }
+
+    around do |example|
+      prior_async = subject.configuration.async
+      subject.configuration.async = proc { :ok }
+      example.run
+      subject.configuration.async = prior_async
+    end
+
+    it 'sends the result of Event.capture_message' do
+      expect(Raven::Event).to receive(:from_message).with(message, options)
+      expect(subject).not_to receive(:send_event).with(event)
+
+      expect(subject.configuration.async).to receive(:call).with(event)
+      subject.capture_message(message, options)
+    end
+
+    it 'returns the generated event' do
+      returned = subject.capture_message(message, options)
+      expect(returned).to eq(event)
+    end
+  end
+
+  describe '#capture_exception' do
+    let(:exception) { build_exception }
+
+    it 'sends the result of Event.capture_exception' do
+      expect(Raven::Event).to receive(:from_exception).with(exception, options)
+      expect(subject).to receive(:send_event).with(event)
+
+      subject.capture_exception(exception, options)
+    end
+
+    it 'yields the event to a passed block' do
+      expect { |b| subject.capture_exception(exception, options, &b) }.to yield_with_args(event)
+    end
+  end
+
+  describe '#capture_exception when async' do
+    let(:exception) { build_exception }
+
+    around do |example|
+      prior_async = subject.configuration.async
+      subject.configuration.async = proc { :ok }
+      example.run
+      subject.configuration.async = prior_async
+    end
+
+    it 'sends the result of Event.capture_exception' do
+      expect(Raven::Event).to receive(:from_exception).with(exception, options)
+      expect(subject).not_to receive(:send_event).with(event)
+
+      expect(subject.configuration.async).to receive(:call).with(event)
+      subject.capture_exception(exception, options)
+    end
+
+    it 'returns the generated event' do
+      returned = subject.capture_exception(exception, options)
+      expect(returned).to eq(event)
+    end
+  end
+
+  describe '#capture_exception with a should_capture callback' do
+    let(:exception) { build_exception }
+
+    it 'sends the result of Event.capture_exception according to the result of should_capture' do
+      expect(subject).not_to receive(:send_event).with(event)
+
+      prior_should_capture = subject.configuration.should_capture
+      subject.configuration.should_capture = proc { false }
+      expect(subject.configuration.should_capture).to receive(:call).with(exception)
+      expect(subject.capture_exception(exception, options)).to be false
+      subject.configuration.should_capture = prior_should_capture
+    end
+  end
+
+  describe '#capture' do
+    context 'given a block' do
+      it 'yields to the given block' do
+        expect { |b| subject.capture(&b) }.to yield_with_no_args
+      end
+    end
+  end
+
+  describe '#annotate_exception' do
+    let(:exception) { build_exception }
+
+    def ivars(object)
+      object.instance_variables.map(&:to_s)
+    end
+
+    it 'adds an annotation to the exception' do
+      expect(ivars(exception)).not_to include("@__raven_context")
+      subject.annotate_exception(exception, {})
+      expect(ivars(exception)).to include("@__raven_context")
+      expect(exception.instance_variable_get(:@__raven_context)).to \
+        be_kind_of Hash
+    end
+  end
+
+  describe '#report_status' do
+    let(:ready_message) do
+      "Raven #{Raven::VERSION} ready to catch errors"
+    end
+
+    let(:not_ready_message) do
+      "Raven #{Raven::VERSION} configured not to send errors."
+    end
+
+    it 'logs a ready message when configured' do
+      subject.configuration.silence_ready = false
+      expect(subject.configuration).to(
+        receive(:send_in_current_environment?).and_return(true)
+      )
+      expect(subject.logger).to receive(:info).with(ready_message)
+      subject.report_status
+    end
+
+    it 'logs not ready message if the config does not send in current environment' do
+      subject.configuration.silence_ready = false
+      expect(subject.configuration).to(
+        receive(:send_in_current_environment?).and_return(false)
+      )
+      expect(subject.logger).to receive(:info).with(not_ready_message)
+      subject.report_status
+    end
+
+    it 'logs nothing if "silence_ready" configuration is true' do
+      subject.configuration.silence_ready = true
+      expect(subject.logger).not_to receive(:info)
+      subject.report_status
+    end
+  end
+
+  describe '.last_event_id' do
+    let(:message) { "Test message" }
+
+    it 'sends the result of Event.capture_message' do
+      expect(subject).to receive(:send_event).with(event)
+
+      subject.capture_message("Test message", options)
+
+      expect(subject.last_event_id).to eq(event.id)
+    end
+
+    it 'yields the event to a passed block' do
+      expect { |b| subject.capture_message(message, options, &b) }.to yield_with_args(event)
+    end
+  end
+end

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -5,7 +5,7 @@ describe Raven do
   let(:options) { double("options") }
 
   before do
-    allow(Raven).to receive(:send_event)
+    allow(Raven.instance).to receive(:send_event)
     allow(Raven::Event).to receive(:from_message) { event }
     allow(Raven::Event).to receive(:from_exception) { event }
   end
@@ -15,7 +15,7 @@ describe Raven do
 
     it 'sends the result of Event.capture_message' do
       expect(Raven::Event).to receive(:from_message).with(message, options)
-      expect(Raven).to receive(:send_event).with(event)
+      expect(Raven.instance).to receive(:send_event).with(event)
 
       Raven.capture_message(message, options)
     end
@@ -54,7 +54,7 @@ describe Raven do
 
     it 'sends the result of Event.capture_exception' do
       expect(Raven::Event).to receive(:from_exception).with(exception, options)
-      expect(Raven).to receive(:send_event).with(event)
+      expect(Raven.instance).to receive(:send_event).with(event)
 
       Raven.capture_exception(exception, options)
     end
@@ -124,7 +124,7 @@ describe Raven do
           pipe_in.close
           described_class.capture(options)
 
-          allow(Raven).to receive(:capture_exception) do |exception, _options|
+          allow(Raven.instance).to receive(:capture_type) do |exception, _options|
             pipe_out.puts exception.message
           end
 
@@ -132,14 +132,13 @@ describe Raven do
           $stderr.reopen('/dev/null', 'w')
           $stdout.reopen('/dev/null', 'w')
 
-          raise 'test error'
+          yield
           exit
         end
 
         pipe_out.close
         captured_messages = pipe_in.read
         pipe_in.close
-
         # sometimes the at_exit hook was registered multiple times
         captured_messages.split("\n").last
       end
@@ -252,7 +251,7 @@ describe Raven do
     let(:message) { "Test message" }
 
     it 'sends the result of Event.capture_message' do
-      expect(Raven).to receive(:send_event).with(event)
+      expect(Raven.instance).to receive(:send_event).with(event)
 
       Raven.capture_message("Test message", options)
 


### PR DESCRIPTION
This refactor was done in 2 steps:

1. Extract methods from Raven's top level module (in base.rb) into Raven::Instance, copy the tests, get them green
1. Delegate from `Raven` to an instance of `Raven::Instance`

These instances may be used like this:
```
class Foo
  def initialize
    @other_raven = Raven::Instance.new
    @other_raven.configure do |config|
      config.server = 'http://...'
    end
  end

  def foo
    ...
  rescue => e
    @other_raven.capture_exception(e)
  end
end
```

Fixes #462.