### PR TITLE
refer to Rack doc in docs/index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,9 +43,11 @@ environment variable or manually configure it with ``Raven.configure``:
 Reporting Failures
 ------------------
 
-If you use Rails, Rake, Rack etc, you're already done - no more
+If you use Rails, Rake, Sidekiq, etc, you're already done - no more
 configuration required! Check :doc:`integrations/index` for more details on
 other gems Sentry integrates with automatically.
+
+Rack requires a little more setup: :doc:`integrations/rack`
 
 Otherwise, Raven supports two methods of capturing exceptions:
 


### PR DESCRIPTION
#### Issue Description

The [ruby client landing page's Configuration section](https://docs.getsentry.com/hosted/clients/ruby/#configuration) incorrectly says "If you use Rails, Rake, Rack etc, you’re already done".

If using Rack, you have to include a `use Raven::Rack`, as it says on [the integrations/rack page](https://docs.getsentry.com/hosted/clients/ruby/integrations/rack/)

Having a reference to the extra Rack setup on the ruby landing page would have saved me a few minutes so I bet it would save other people time too.

#### Disclaimer

I gave it a shot in this PR, but couldn't get `make html` to work, so I'm not totally sure it does what I expect.  Also, I see a sentry-docs repo, so maybe this isn't even the right place anymore!