### PR TITLE
Fix silence_ready not working for Rails apps

### DIFF
--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -24,15 +24,13 @@ module Raven
       end
     end
 
-    config.before_initialize do
+    config.after_initialize do
       Raven.configure do |config|
         config.logger ||= ::Rails.logger
         config.project_root ||= ::Rails.root
-        config.release = config.detect_release # if project_root has changed, need to re-check
+        config.release ||= config.detect_release # if project_root has changed, need to re-check
       end
-    end
 
-    config.after_initialize do
       if Raven.configuration.rails_report_rescued_exceptions
         require 'raven/integrations/rails/overrides/debug_exceptions_catcher'
         if defined?(::ActionDispatch::DebugExceptions)


### PR DESCRIPTION
by invoking the first configure block after your initializers are called. Before, using an initializer would generate a second clients, with the first one still logging to STDOUT.

Until this is merged, someone can use this in his application.rb to get the same result:

    Rails.application.config.before_configuration do
      Raven.configuration.silence_ready = true
    end

See also: https://github.com/getsentry/raven-ruby/issues/492