### PR TITLE
Do not capture if env doesn't match or DSN not set

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -34,7 +34,7 @@ module Raven
 
     def_delegators :instance, :client=, :configuration=, :context, :logger, :configuration,
                    :client, :report_status, :configure, :send_event, :capture, :capture_type,
-                   :last_event_id, :should_capture?, :annotate_exception, :user_context,
+                   :last_event_id, :annotate_exception, :user_context,
                    :tags_context, :extra_context, :rack_context, :breadcrumbs
 
     def_delegator :instance, :report_status, :report_ready

--- a/lib/raven/cli.rb
+++ b/lib/raven/cli.rb
@@ -14,7 +14,7 @@ module Raven
       Raven.configuration.dsn = dsn if dsn
 
       # wipe out env settings to ensure we send the event
-      unless Raven.configuration.send_in_current_environment?
+      unless Raven.configuration.capture_in_current_environment?
         env_name = Raven.configuration.environments.pop || 'production'
         puts "Setting environment to #{env_name}"
         Raven.configuration.current_environment = env_name

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -22,7 +22,7 @@ module Raven
     end
 
     def send_event(event)
-      return false unless configuration_allows_sending
+      return false unless configuration.sending_allowed?(event)
 
       # Convert to hash
       event = event.to_hash
@@ -61,15 +61,6 @@ module Raven
     end
 
     private
-
-    def configuration_allows_sending
-      if configuration.send_in_current_environment?
-        true
-      else
-        configuration.log_excluded_environment_message
-        false
-      end
-    end
 
     def encode(event)
       hash = @processors.reduce(event.to_hash) { |memo, p| p.process(memo) }

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -215,12 +215,21 @@ module Raven
       @current_environment = environment.to_s
     end
 
-    def send_in_current_environment?
+    def capture_allowed?(message_or_exc)
+      capture_in_current_environment? &&
+        capture_allowed_by_callback?(message_or_exc)
+    end
+
+    # If we cannot capture, we cannot send.
+    alias sending_allowed? capture_allowed?
+
+    def capture_in_current_environment?
       !!server && (environments.empty? || environments.include?(current_environment))
     end
 
-    def log_excluded_environment_message
-      Raven.logger.debug "Event not sent due to excluded environment: #{current_environment}"
+    def capture_allowed_by_callback?(message_or_exc)
+      return true unless should_capture
+      should_capture.call(*[message_or_exc])
     end
 
     def verify!

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -66,7 +66,7 @@ describe Raven::Configuration do
 
     it 'should not send events' do
       expect(subject[:server]).to eq(nil)
-      expect(subject.send_in_current_environment?).to eq(false)
+      expect(subject.capture_in_current_environment?).to eq(false)
     end
   end
 
@@ -131,12 +131,12 @@ describe Raven::Configuration do
 
     it 'should send events if test is whitelisted' do
       subject.environments = %w[test]
-      expect(subject.send_in_current_environment?).to eq(true)
+      expect(subject.capture_in_current_environment?).to eq(true)
     end
 
     it 'should not send events if test is not whitelisted' do
       subject.environments = %w[not_test]
-      expect(subject.send_in_current_environment?).to eq(false)
+      expect(subject.capture_in_current_environment?).to eq(false)
     end
   end
 

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -11,6 +11,8 @@ describe Raven::Instance do
     allow(subject).to receive(:send_event)
     allow(Raven::Event).to receive(:from_message) { event }
     allow(Raven::Event).to receive(:from_exception) { event }
+
+    subject.configuration.dsn = "dummy://woopwoop"
   end
 
   describe '#context' do
@@ -141,13 +143,13 @@ describe Raven::Instance do
     end
 
     let(:not_ready_message) do
-      "Raven #{Raven::VERSION} configured not to send errors."
+      "Raven #{Raven::VERSION} configured not to capture errors."
     end
 
     it 'logs a ready message when configured' do
       subject.configuration.silence_ready = false
       expect(subject.configuration).to(
-        receive(:send_in_current_environment?).and_return(true)
+        receive(:capture_in_current_environment?).and_return(true)
       )
       expect(subject.logger).to receive(:info).with(ready_message)
       subject.report_status
@@ -156,7 +158,7 @@ describe Raven::Instance do
     it 'logs not ready message if the config does not send in current environment' do
       subject.configuration.silence_ready = false
       expect(subject.configuration).to(
-        receive(:send_in_current_environment?).and_return(false)
+        receive(:capture_in_current_environment?).and_return(false)
       )
       expect(subject.logger).to receive(:info).with(not_ready_message)
       subject.report_status

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -181,13 +181,13 @@ describe Raven do
     end
 
     let(:not_ready_message) do
-      "Raven #{Raven::VERSION} configured not to send errors."
+      "Raven #{Raven::VERSION} configured not to capture errors."
     end
 
     it 'logs a ready message when configured' do
       Raven.configuration.silence_ready = false
       expect(Raven.configuration).to(
-        receive(:send_in_current_environment?).and_return(true)
+        receive(:capture_in_current_environment?).and_return(true)
       )
       expect(Raven.logger).to receive(:info).with(ready_message)
       Raven.report_status
@@ -196,7 +196,7 @@ describe Raven do
     it 'logs not ready message if the config does not send in current environment' do
       Raven.configuration.silence_ready = false
       expect(Raven.configuration).to(
-        receive(:send_in_current_environment?).and_return(false)
+        receive(:capture_in_current_environment?).and_return(false)
       )
       expect(Raven.logger).to receive(:info).with(not_ready_message)
       Raven.report_status


### PR DESCRIPTION
Previously, even when event *sending* to the server was disabled by lack of a DSN or the current environment not matching the env list, we would still capture a Raven event. This commit causes Raven to not even capture events when it would not send them.

cc @dcramer - any legitimate reason people want to capture but not send?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-ruby/518)
<!-- Reviewable:end -->
