### PR TITLE
Send environment from current_environment

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -26,7 +26,7 @@ module Raven
     attr_reader :id
     attr_accessor :project, :message, :timestamp, :time_spent, :level, :logger,
       :culprit, :server_name, :release, :modules, :extra, :tags, :context, :configuration,
-      :checksum, :fingerprint
+      :checksum, :fingerprint, :environment
 
     def initialize(init = {})
       @configuration = Raven.configuration
@@ -49,6 +49,7 @@ module Raven
       @tags          = {}
       @checksum      = nil
       @fingerprint   = nil
+      @environment   = @configuration.current_environment
 
       yield self if block_given?
 
@@ -220,6 +221,7 @@ module Raven
       data[:culprit] = @culprit if @culprit
       data[:server_name] = @server_name if @server_name
       data[:release] = @release if @release
+      data[:environment] = @envirionment if @environment
       data[:fingerprint] = @fingerprint if @fingerprint
       data[:modules] = @modules if @modules
       data[:extra] = @extra if @extra


### PR DESCRIPTION
Future change might involve renaming current_environment to environment and environments to something that looks like like the core attribute.

@getsentry/ruby

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-ruby/530)
<!-- Reviewable:end -->
