### PR TITLE
Ensure @port is always initialized

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -181,7 +181,7 @@ module Raven
 
       @scheme = uri.scheme
       @host = uri.host
-      @port = uri.port if uri.port
+      @port = uri.port ? uri.port : nil
       @path = uri_path.join('/')
 
       # For anyone who wants to read the base server string


### PR DESCRIPTION
We are getting warnings about the port not being initialized. This change ensures that the `@port` variable is always defined before it is used as to avoid these warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-ruby/533)
<!-- Reviewable:end -->
