### PR TITLE
Log4r compat problems

### DIFF
--- a/lib/raven/logger.rb
+++ b/lib/raven/logger.rb
@@ -5,14 +5,6 @@ module Raven
   class Logger
     LOG_PREFIX = "** [Raven] ".freeze
 
-    LEVELS = {
-      :debug => ::Logger::DEBUG,
-      :info => ::Logger::INFO,
-      :warn => ::Logger::WARN,
-      :error => ::Logger::ERROR,
-      :fatal => ::Logger::FATAL
-    }.freeze
-
     [
       :fatal,
       :error,
@@ -21,12 +13,14 @@ module Raven
       :debug,
     ].each do |level|
       define_method level do |*args, &block|
-        msg = args[0] # Block-level default args is a 1.9 feature
-        msg ||= block.call if block
         logger = Raven.configuration[:logger]
         logger = ::Logger.new(STDOUT) if logger.nil?
+        return unless logger
 
-        logger.add(LEVELS[level], "#{LOG_PREFIX}#{msg}", "sentry") if logger
+        msg = args[0] # Block-level default args is a 1.9 feature
+        msg ||= block.call if block
+
+        logger.send(level, "sentry") { "#{LOG_PREFIX}#{msg}" }
       end
     end
   end

--- a/spec/raven/logger_spec.rb
+++ b/spec/raven/logger_spec.rb
@@ -11,39 +11,20 @@ describe Raven::Logger do
     end
   end
 
+  # Currently not testing the output here
   context 'with a backend logger' do
     before do
       @logger = double('logger')
       allow(Raven.configuration).to receive(:logger) { @logger }
     end
 
-    it 'should log fatal messages' do
-      expect(@logger).to receive(:add).with(Logger::FATAL, '** [Raven] fatalmsg', 'sentry')
+    it 'should log to the provided logger' do
+      expect(@logger).to receive(:fatal).with('sentry')
       subject.fatal 'fatalmsg'
     end
 
-    it 'should log error messages' do
-      expect(@logger).to receive(:add).with(Logger::ERROR, '** [Raven] errormsg', 'sentry')
-      subject.error 'errormsg'
-    end
-
-    it 'should log warning messages' do
-      expect(@logger).to receive(:add).with(Logger::WARN, '** [Raven] warnmsg', 'sentry')
-      subject.warn 'warnmsg'
-    end
-
-    it 'should log info messages' do
-      expect(@logger).to receive(:add).with(Logger::INFO, '** [Raven] infomsg', 'sentry')
-      subject.info 'infomsg'
-    end
-
-    it 'should log debug messages' do
-      expect(@logger).to receive(:add).with(Logger::DEBUG, '** [Raven] debugmsg', 'sentry')
-      subject.debug 'debugmsg'
-    end
-
     it 'should log messages from blocks' do
-      expect(@logger).to receive(:add).with(Logger::INFO, '** [Raven] infoblock', 'sentry')
+      expect(@logger).to receive(:info).with('sentry')
       subject.info { 'infoblock' }
     end
   end


### PR DESCRIPTION
When this was changed from `send` to `add` I think we just did it because it was easier to test. I can't think of a great way to test the provided block here, so we're not really testing the log output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-ruby/535)
<!-- Reviewable:end -->
