### PR TITLE
Pass JSON-compatible hashes to `async`

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -247,6 +247,10 @@ module Raven
       "#{lastframe.filename} in #{lastframe.function} at line #{lastframe.lineno}" if lastframe
     end
 
+    def to_json_compatible
+      JSON.parse(JSON.generate(to_hash))
+    end
+
     # For cross-language compat
     class << self
       alias captureException from_exception

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -120,7 +120,9 @@ module Raven
         yield evt if block_given?
         if configuration.async?
           begin
-            configuration.async.call(evt)
+            # We have to convert to a JSON-like hash, because background job
+            # processors (esp ActiveJob) may not like weird types in the event hash
+            configuration.async.call(evt.to_json_compatible)
           rescue => ex
             Raven.logger.error("async event sending failed: #{ex.message}")
             send_event(evt)

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -331,6 +331,24 @@ describe Raven::Event do
     end
   end
 
+  describe '.to_json_compatible' do
+    subject do
+      Raven::Event.new(:extra => {
+                         'my_custom_variable' => 'value',
+                         'date' => Time.utc(0),
+                         'anonymous_module' => Class.new
+                       })
+    end
+
+    it "should coerce non-JSON-compatible types" do
+      json = subject.to_json_compatible
+
+      expect(json["extra"]['my_custom_variable']).to eq('value')
+      expect(json["extra"]['date']).to be_a(String)
+      expect(json["extra"]['anonymous_module']).not_to be_a(Class)
+    end
+  end
+
   describe '.capture_message' do
     let(:message) { 'This is a message' }
     let(:hash) { Raven::Event.capture_message(message).to_hash }

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'raven/instance'
 
 describe Raven::Instance do
-  let(:event) { double("event", :id => "event_id") }
+  let(:event) { Raven::Event.new(:id => "event_id") }
   let(:options) { double("options") }
   let(:context) { nil }
 
@@ -60,7 +60,7 @@ describe Raven::Instance do
         expect(Raven::Event).to receive(:from_message).with(message, options)
         expect(subject).not_to receive(:send_event).with(event)
 
-        expect(subject.configuration.async).to receive(:call).with(event)
+        expect(subject.configuration.async).to receive(:call).with(event.to_json_compatible)
         subject.capture_type(message, options)
       end
 
@@ -100,7 +100,7 @@ describe Raven::Instance do
           expect(Raven::Event).to receive(:from_exception).with(exception, options)
           expect(subject).not_to receive(:send_event).with(event)
 
-          expect(subject.configuration.async).to receive(:call).with(event)
+          expect(subject.configuration.async).to receive(:call).with(event.to_json_compatible)
           subject.capture_type(exception, options)
         end
 
@@ -121,7 +121,7 @@ describe Raven::Instance do
         it 'sends the result of Event.capture_exception via fallback' do
           expect(Raven::Event).to receive(:from_exception).with(exception, options)
 
-          expect(subject).to receive(:send_event).with(event)
+          expect(subject.configuration.async).to receive(:call).with(event.to_json_compatible)
           subject.capture_type(exception, options)
         end
       end

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Raven do
-  let(:event) { double("event", :id => "event_id") }
+  let(:event) { Raven::Event.new(:id => "event_id") }
   let(:options) { double("options") }
 
   before do
@@ -39,7 +39,7 @@ describe Raven do
       expect(Raven::Event).to receive(:from_message).with(message, options)
       expect(Raven).not_to receive(:send_event).with(event)
 
-      expect(Raven.configuration.async).to receive(:call).with(event)
+      expect(Raven.configuration.async).to receive(:call).with(event.to_json_compatible)
       Raven.capture_message(message, options)
     end
 
@@ -78,7 +78,7 @@ describe Raven do
       expect(Raven::Event).to receive(:from_exception).with(exception, options)
       expect(Raven).not_to receive(:send_event).with(event)
 
-      expect(Raven.configuration.async).to receive(:call).with(event)
+      expect(Raven.configuration.async).to receive(:call).with(event.to_json_compatible)
       Raven.capture_exception(exception, options)
     end
 


### PR DESCRIPTION
Fixes #511.

This changes the type of the object given to the `async` callback.

This change will *break* any async callback like the following:

```ruby
SentryJob = Struct.new(:event) do
  def perform
    Raven.send_event(event)
  end
end

Raven.configure do |config|
  config.async = lambda { |event|
    event.extra = { 'some_stuff' => 'modified_here' }
    Delayed::Job.enqueue SentryJob.new(event.to_hash)
  }
end
```

It *will not break* the most common async setup, which looks like:

```ruby
SentryJob = Struct.new(:event) do
  def perform
    Raven.send_event(event)
  end
end

Raven.configure do |config|
  config.async = lambda { |event|
    Delayed::Job.enqueue SentryJob.new(event.to_hash)
  }
end
```

Benchmarks indicate that this slows down capture by 2-3x, though using `async` is still an order of magnitude faster than not using it (not including HTTP costs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-ruby/547)
<!-- Reviewable:end -->
