### PR TITLE
Do not implicitly set up rack-timeout middleware

### DIFF
--- a/lib/raven/integrations/rack-timeout.rb
+++ b/lib/raven/integrations/rack-timeout.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Style/FileName
 # We need to do this because of the way integration loading works
-require 'rack-timeout'
+require "rack/timeout/base"
 
 # This integration is a good example of how to change how exceptions
 # get grouped by Sentry's UI. Simply override #raven_context in


### PR DESCRIPTION
By requiring `rack-timeout`, `Rack::Timeout` is automatically added to the middleware of a Rails application. 

See https://github.com/heroku/rack-timeout#rails-apps

This leads to unexpected behavior. When a user adds a non-standard `Rack-Timeout` to the middleware stack herself, she ends up with `Rack-Timeout` added twice. Worse, the configuration added automatically is the standard configuration which might differ from the one added manually in user land. Worst case comes to show when a user configures a `service_timeout` greater than the standard one.

The `"rack/timeout/base"` entry point was added in `v0.3.0` of `rack-timeout`, see https://github.com/heroku/rack-timeout/commit/39fdbae083e24fb886c8ca459f1c6ed3c07a487e.

I would advice to fix this rather sooner than later as all Rails apps using `sentry-raven` and `rack-timeout` with its manual configuration are affected by this.