### PR TITLE
Fix Rails 5 `params.to_hash` deprecation warning in docs

### DIFF
--- a/docs/integrations/rails.rst
+++ b/docs/integrations/rails.rst
@@ -49,7 +49,7 @@ Params and sessions
 
     def set_raven_context
       Raven.user_context(id: session[:current_user_id]) # or anything else in session
-      Raven.extra_context(params: params.to_hash, url: request.url)
+      Raven.extra_context(params: params.to_unsafe_h, url: request.url)
     end
   end
 


### PR DESCRIPTION
In Rails 5.0, calling `params.to_hash` logs a deprecation warning [0],
so we should be advising our users to call to_unsafe_h as rails 5.1 will
just raise an error. This code is compatible with rails 4.2.

[0] - https://github.com/rails/rails/issues/23084