### PR TITLE
Travis: Test against jruby-9.1.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ matrix:
     - rvm: jruby-1.7.24
       env: JRUBY_OPTS="--2.0"
       gemfile: gemfiles/rails42.gemfile
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.5.0
       gemfile: gemfiles/rails42.gemfile
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.5.0
       gemfile: gemfiles/rails5.gemfile
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
This PR is a proposal to test JRuby 9K against latest stable.

(Before, it was set to jruby-9.0.5.0.)

