### PR TITLE
MessageInterface support for invalid format string msg when params is…

### DIFF
--- a/lib/raven/interfaces/message.rb
+++ b/lib/raven/interfaces/message.rb
@@ -10,7 +10,7 @@ module Raven
     end
 
     def unformatted_message
-      message % params
+      params.nil? ? message : message % params
     end
 
     def self.sentry_alias

--- a/spec/raven/interface_spec.rb
+++ b/spec/raven/interface_spec.rb
@@ -27,7 +27,7 @@ end
 
 describe Raven::MessageInterface do
   it "supports invalid format string message when params is not defined" do
-    interface = Raven::MessageInterface.new(:message => "test '%'")
+    interface = Raven::MessageInterface.new(:params => nil, :message => "test '%'")
     expect(interface.unformatted_message).to eq("test '%'")
   end
 end

--- a/spec/raven/interface_spec.rb
+++ b/spec/raven/interface_spec.rb
@@ -24,3 +24,10 @@ describe Raven::Interface do
     expect(interface.to_hash).to eq(:some_attr => "test")
   end
 end
+
+describe Raven::MessageInterface do
+  it "supports invalid format string message when params is not defined" do
+    interface = Raven::MessageInterface.new(:message => "test '%'")
+    expect(interface.unformatted_message).to eq("test '%'")
+  end
+end


### PR DESCRIPTION
We were having a problem were certain errors were not being reported.

The cause was that `MessageInterface#unformatted_message` was producing an _ArgumentError: malformed format string_.  This was due to the message being an invalid format string (e.g.: _Process failed at char '%'_). This occurred even tough there were no `params` defined.

I changed the behaviour of `MessageInterface#unformatted_message` to not apply the `params` to the `message` using `%` if there were no `params` defined. 

Not sure if there a more appropriate way to solve this issue. In any case the test case might be helpful.