### PR TITLE
Travis: add ruby.launch.inproc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: false
 matrix:
   include:
     - rvm: jruby-1.7.26
-      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true"
+      env: JRUBY_OPTS="--dev"
       gemfile: gemfiles/rails42.gemfile
     - rvm: jruby-9.1.5.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ sudo: false
 matrix:
   include:
     - rvm: jruby-1.7.26
-      env: JRUBY_OPTS="--dev"
+      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true"
       gemfile: gemfiles/rails42.gemfile
     - rvm: jruby-9.1.5.0
-      env: JRUBY_OPTS="--dev"
+      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true"
       gemfile: gemfiles/rails42.gemfile
     - rvm: jruby-9.1.5.0
-      env: JRUBY_OPTS="--dev"
+      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true"
       gemfile: gemfiles/rails5.gemfile
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
The JRuby option `ruby.launch.inproc` is mentioned in #571.

This PR tries to run a build with that option. [The JRuby wiki page on performance explains](https://github.com/jruby/jruby/wiki/Improving-startup-time#avoid-spawning-sub-rubies).

This is the bit where it would be beneficial to not have to start another JVM:
https://github.com/getsentry/raven-ruby/blob/master/lib/raven/context.rb#L37