### PR TITLE
Travis: Ruby 2.4.0-preview2 supported, just

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
       gemfile: gemfiles/rails5.gemfile
   allow_failures:
     - rvm: ruby-head
-    - rvm: 2.4.0-preview2
   exclude:
     - rvm: 2.2
       gemfile: gemfiles/rails32.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gemspec
 group :test do
   gem "rack"
   gem "sidekiq"
+  if RUBY_VERSION > '2.4'
+    gem "json", ">= 2"
+  end
 end
 
 group :development do
@@ -12,5 +15,9 @@ group :development do
   gem "pry-coolline"
   gem "benchmark-ips"
   gem "benchmark-ipsa"
-  gem "yajl-ruby", :platforms => :mri
+  if RUBY_VERSION > '2.4'
+    gem "yajl-ruby", git: 'https://github.com/brianmario/yajl-ruby.git', ref: '6f39ff8c3611edbf4edca1d0cc3ddc15aa5e4e92'
+  else
+    gem "yajl-ruby", :platforms => :mri
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,6 @@ gemspec
 group :test do
   gem "rack"
   gem "sidekiq"
-  if RUBY_VERSION > '2.4'
-    gem "json", ">= 2"
-  end
 end
 
 group :development do
@@ -19,5 +16,11 @@ group :development do
     gem "yajl-ruby", git: 'https://github.com/brianmario/yajl-ruby.git', ref: '6f39ff8c3611edbf4edca1d0cc3ddc15aa5e4e92'
   else
     gem "yajl-ruby", :platforms => :mri
+  end
+end
+
+group :test, :development do
+  if RUBY_VERSION > '2.4'
+    gem "json", ">= 2"
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,14 +13,12 @@ group :development do
   gem "benchmark-ips"
   gem "benchmark-ipsa"
   if RUBY_VERSION > '2.4'
-    gem "yajl-ruby", git: 'https://github.com/brianmario/yajl-ruby.git', ref: '6f39ff8c3611edbf4edca1d0cc3ddc15aa5e4e92'
+    gem "yajl-ruby", :git => 'https://github.com/brianmario/yajl-ruby.git', :ref => '6f39ff8c3611edbf4edca1d0cc3ddc15aa5e4e92'
   else
     gem "yajl-ruby", :platforms => :mri
   end
 end
 
 group :test, :development do
-  if RUBY_VERSION > '2.4'
-    gem "json", ">= 2"
-  end
+  gem "json", ">= 2" if RUBY_VERSION > '2.4'
 end


### PR DESCRIPTION
This PR elbows in support for 2.4.0-preview2 to be able to run the test suite.

It conditionally adds these gems to the Gemfile:

- json 2.x
- yayl-ruby at a very recent commit (no release of the gem as yet)

And it removes 2.4.0-preview2 from allowed failures.