### PR TITLE
Add reason to capture info message

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -248,7 +248,8 @@ module Raven
     end
 
     def capture_allowed?(message_or_exc = nil)
-      capture_in_current_environment? &&
+      server_configured? &&
+        capture_in_current_environment? &&
         capture_allowed_by_callback?(message_or_exc)
     end
 
@@ -259,6 +260,13 @@ module Raven
       %w(server public_key secret_key project_id).each do |key|
         raise(Error, "No #{key} specified") unless public_send key
       end
+    end
+
+    def verify_messages
+      messages = []
+      messages << 'no server configured' unless server_configured?
+      messages << 'current environment not listed' unless capture_in_current_environment?
+      messages
     end
 
     def project_root=(root_dir)
@@ -299,7 +307,11 @@ module Raven
     end
 
     def capture_in_current_environment?
-      !!server && (environments.empty? || environments.include?(current_environment))
+      environments.empty? || environments.include?(current_environment)
+    end
+
+    def server_configured?
+      host && path
     end
 
     def capture_allowed_by_callback?(message_or_exc)

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -257,7 +257,7 @@ module Raven
     alias sending_allowed? capture_allowed?
 
     def verify!
-      %w(server public_key secret_key project_id).each do |key|
+      %w(server host path public_key secret_key project_id).each do |key|
         raise(Error, "No #{key} specified") unless public_send key
       end
     end
@@ -311,7 +311,10 @@ module Raven
     end
 
     def server_configured?
-      host && path
+      verify!
+      true
+    rescue Error
+      false
     end
 
     def capture_allowed_by_callback?(message_or_exc)

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -61,7 +61,8 @@ module Raven
       if configuration.capture_allowed?
         logger.info "Raven #{VERSION} ready to catch errors"
       else
-        logger.info "Raven #{VERSION} configured not to capture errors."
+        reasons = configuration.verify_messages.join(', ')
+        logger.info "Raven #{VERSION} configured not to capture errors (#{reasons})."
       end
     end
 

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -60,7 +60,7 @@ describe Raven::Configuration do
   context 'being initialized with a current environment' do
     before(:each) do
       subject.current_environment = 'test'
-      subject.server = 'http://sentry.localdomain/sentry'
+      subject.server = "http://12345:67890@sentry.localdomain:3000/sentry/42"
     end
 
     it 'should send events if test is whitelisted' do
@@ -77,7 +77,7 @@ describe Raven::Configuration do
   context 'with a should_capture callback configured' do
     before(:each) do
       subject.should_capture = ->(exc_or_msg) { exc_or_msg != "dont send me" }
-      subject.server = 'http://sentry.localdomain/sentry'
+      subject.server = "http://12345:67890@sentry.localdomain:3000/sentry/42"
     end
 
     it 'should not send events if should_capture returns false' do
@@ -89,7 +89,7 @@ describe Raven::Configuration do
   it "should verify server configuration, looking for missing keys" do
     expect { subject.verify! }.to raise_error(Raven::Error, "No server specified")
 
-    subject.server, subject.public_key, subject.secret_key, subject.project_id = "", "", "", ""
+    subject.server, subject.host, subject.path, subject.public_key, subject.secret_key, subject.project_id = "", "", "", "", "", ""
 
     subject.verify!
   end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -93,4 +93,34 @@ describe Raven::Configuration do
 
     subject.verify!
   end
+
+  describe '#verify_messages' do
+    context 'when configured to capture events' do
+      it 'should stay empty' do
+        subject.server = "http://12345:67890@sentry.localdomain:3000/sentry/42"
+        subject.environments = %w(test)
+        subject.current_environment = 'test'
+
+        expect(subject.verify_messages).to eq([])
+      end
+    end
+
+    context 'when server is not set' do
+      it 'should say that' do
+        subject.server = ''
+
+        expect(subject.verify_messages).to include('no server configured')
+      end
+    end
+
+    context 'when current environment is not listed' do
+      it 'should say that' do
+        subject.server = "http://12345:67890@sentry.localdomain:3000/sentry/42"
+        subject.environments = %w(not_test)
+        subject.current_environment = 'test'
+
+        expect(subject.verify_messages).to include('current environment not listed')
+      end
+    end
+  end
 end

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -13,7 +13,7 @@ describe Raven::Instance do
     allow(Raven::Event).to receive(:from_message) { event }
     allow(Raven::Event).to receive(:from_exception) { event }
 
-    subject.configuration.dsn = "dummy://woopwoop"
+    subject.configuration.dsn = "http://12345:67890@sentry.localdomain:3000/sentry/42"
   end
 
   describe '#context' do

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -170,36 +170,45 @@ describe Raven::Instance do
   end
 
   describe '#report_status' do
-    let(:ready_message) do
-      "Raven #{Raven::VERSION} ready to catch errors"
+    context 'when configured' do
+      let(:message) do
+        "Raven #{Raven::VERSION} ready to catch errors"
+      end
+
+      it 'logs a ready message' do
+        subject.configuration.silence_ready = false
+        expect(subject.configuration).to(
+          receive(:capture_allowed?).and_return(true)
+        )
+        expect(subject.logger).to receive(:info).with(message)
+        subject.report_status
+      end
     end
 
-    let(:not_ready_message) do
-      "Raven #{Raven::VERSION} configured not to capture errors."
+    context 'when "silence_ready" configuration is true' do
+      it 'logs nothing' do
+        subject.configuration.silence_ready = true
+        expect(subject.logger).not_to receive(:info)
+        subject.report_status
+      end
     end
 
-    it 'logs a ready message when configured' do
-      subject.configuration.silence_ready = false
-      expect(subject.configuration).to(
-        receive(:capture_allowed?).and_return(true)
-      )
-      expect(subject.logger).to receive(:info).with(ready_message)
-      subject.report_status
-    end
+    context 'when config does not send in current environment' do
+      let(:not_ready_message) do
+        "Raven #{Raven::VERSION} configured not to capture errors (current environment not listed)."
+      end
 
-    it 'logs not ready message if the config does not send in current environment' do
-      subject.configuration.silence_ready = false
-      expect(subject.configuration).to(
-        receive(:capture_allowed?).and_return(false)
-      )
-      expect(subject.logger).to receive(:info).with(not_ready_message)
-      subject.report_status
-    end
-
-    it 'logs nothing if "silence_ready" configuration is true' do
-      subject.configuration.silence_ready = true
-      expect(subject.logger).not_to receive(:info)
-      subject.report_status
+      it 'logs not ready message' do
+        subject.configuration.silence_ready = false
+        expect(subject.configuration).to(
+          receive(:capture_allowed?).and_return(false)
+        )
+        expect(subject.configuration).to(
+          receive(:verify_messages).and_return(['current environment not listed'])
+        )
+        expect(subject.logger).to receive(:info).with(not_ready_message)
+        subject.report_status
+      end
     end
   end
 

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -5,9 +5,11 @@ describe Raven do
   let(:options) { double("options") }
 
   before do
+    Raven.instance_variable_set(:@instance, nil)
     allow(Raven.instance).to receive(:send_event)
     allow(Raven::Event).to receive(:from_message) { event }
     allow(Raven::Event).to receive(:from_exception) { event }
+    Raven.configuration.server = "dummy://woopwoop"
   end
 
   describe '.capture_message' do
@@ -28,11 +30,8 @@ describe Raven do
   describe '.capture_message when async' do
     let(:message) { "Test message" }
 
-    around do |example|
-      prior_async = Raven.configuration.async
+    before do
       Raven.configuration.async = proc { :ok }
-      example.run
-      Raven.configuration.async = prior_async
     end
 
     it 'sends the result of Event.capture_message' do
@@ -67,11 +66,8 @@ describe Raven do
   describe '.capture_exception when async' do
     let(:exception) { build_exception }
 
-    around do |example|
-      prior_async = Raven.configuration.async
+    before do
       Raven.configuration.async = proc { :ok }
-      example.run
-      Raven.configuration.async = prior_async
     end
 
     it 'sends the result of Event.capture_exception' do

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -9,7 +9,7 @@ describe Raven do
     allow(Raven.instance).to receive(:send_event)
     allow(Raven::Event).to receive(:from_message) { event }
     allow(Raven::Event).to receive(:from_exception) { event }
-    Raven.configuration.server = "dummy://woopwoop"
+    Raven.configuration.server = "http://12345:67890@sentry.localdomain:3000/sentry/42"
   end
 
   describe '.capture_message' do


### PR DESCRIPTION
This PR addresses issue #568 and adds an explanatory messages to the `#report_status` method (which gets outputted on startup) telling the user why events won't be captured.
- I'm not totally happy with the naming of `verify_messages` - maybe "reasons" somewhere in there would fit better?
- I've introduced `Configuration#server_configured?`, which is replacing `!!server` in `#capture_in_current_environment?`. Turns out that the double negation always returned `true` because of the way how `@server` is [assembled](https://github.com/getsentry/raven-ruby/blob/d2c51187ae944f80a9212173d7872f82fe9368d4/lib/raven/configuration.rb#L207-L209). How about we use `uri.to_s` here? That would returns an empty string for an empty configuration value.
- The specs for the `Raven` class were not green when only running that spec. That's fixed by d7b14bd, which resets the instance variable for each test run.
- I've made the specs for `#report_status` in the `Raven` class more integration-like, as they were basically the same specs as for the `Instance` class. They are now changing "real" configuration values.

Happy for any kind of feedback!
