### PR TITLE
Always match excluded exceptions by case equality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
     - 'lib/raven/utils/deep_merge.rb'
 
 Metrics/ClassLength:
-  Max: 233
+  Max: 246
   CountComments: false
 
 Metrics/AbcSize:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
     - 'lib/raven/utils/deep_merge.rb'
 
 Metrics/ClassLength:
-  Max: 246
+  Max: 248
   CountComments: false
 
 Metrics/AbcSize:

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -136,8 +136,6 @@ module Raven
 
       def get_exception_class(x)
         x.is_a?(Module) ? x : qualified_const_get(x)
-      rescue NameError # There's no way to safely ask if a constant exist for an unknown string
-        nil
       end
 
       # In Ruby <2.0 const_get can't lookup "SomeModule::SomeClass" in one go
@@ -148,6 +146,8 @@ module Raven
         else
           parts.inject(Object) { |a, e| a.const_get(e) }
         end
+      rescue NameError # There's no way to safely ask if a constant exist for an unknown string
+        nil
       end
 
       def get_exception_context(exc)

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -140,9 +140,12 @@ module Raven
 
       # In Ruby <2.0 const_get can't lookup "SomeModule::SomeClass" in one go
       def qualified_const_get(x)
-        parts = x.to_s.split("::").delete_if(&:empty?)
+        x = x.to_s
+        parts = x.split("::")
+        parts.reject!(&:empty?)
+
         if parts.size < 2
-          Object.const_get(x.to_s)
+          Object.const_get(x)
         else
           parts.inject(Object) { |a, e| a.const_get(e) }
         end


### PR DESCRIPTION
... no matter if they are defined by string or constant in
Raven.configuration[:excluded_exceptions].

The upside of doing it like this is that Raven will have the same match
behavior no matter how the exception was excluded. Previously a
string-defined excluded exception wouldn't match inherited/extended
exceptions.

Use case example:

```Ruby
  # Raven setup
  Raven.configure do |config|
    config.excluded_exceptions = ["SentryExcludedException"]
  end

  # Application
  module SentryExcludedException; end

  # The application can decide what to exclude
  begin
    raise StandardError, "oh snap"
  rescue => error
    error.extend SentryExcludedException
    raise
  end
```

This only worked if the excluded_exceptions was configured with
constants, but not with strings, which this fixes.

By using strings the coupling between the Raven setup/environment
and the application is reduced, improving unit testing etc.