### PR TITLE
Adding header info to the error message if any

### DIFF
--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -24,7 +24,9 @@ module Raven
           req.body = data
         end
       rescue Faraday::ClientError => ex
-        raise Raven::Error, ex.message
+        error_info = ex.message
+        error_info += " Error in headers is: #{ex.response[:headers]['x-sentry-error']}" if ex.response[:headers]['x-sentry-error']
+        raise Raven::Error, error_info
       end
 
       private


### PR DESCRIPTION
In case we are debugging any strange error this information can be
super useful.

I was finding a lot of errors and the header sometimes adds useful hints. 

I don't know if the format of the error is adequate or if you prefer logging in a different fashion.

Thanks a lot!