### PR TITLE
Move OS/runtime context to extra

### DIFF
--- a/lib/raven/context.rb
+++ b/lib/raven/context.rb
@@ -13,10 +13,10 @@ module Raven
     attr_accessor :extra, :server_os, :rack_env, :runtime, :tags, :user
 
     def initialize
-      self.extra = {}
       self.server_os = self.class.os_context
-      self.rack_env = nil
       self.runtime = self.class.runtime_context
+      self.extra = { :server => { :os => server_os, :runtime => runtime } }
+      self.rack_env = nil
       self.tags = {}
       self.user = {}
     end
@@ -24,17 +24,17 @@ module Raven
     class << self
       def os_context
         @os_context ||= {
-          "name" => Raven.sys_command("uname -s") || RbConfig::CONFIG["host_os"],
-          "version" => Raven.sys_command("uname -v"),
-          "build" => Raven.sys_command("uname -r"),
-          "kernel_version" => Raven.sys_command("uname -a") || Raven.sys_command("ver") # windows
+          :name => Raven.sys_command("uname -s") || RbConfig::CONFIG["host_os"],
+          :version => Raven.sys_command("uname -v"),
+          :build => Raven.sys_command("uname -r"),
+          :kernel_version => Raven.sys_command("uname -a") || Raven.sys_command("ver") # windows
         }
       end
 
       def runtime_context
         @runtime_context ||= {
-          "name" => RbConfig::CONFIG["ruby_install_name"],
-          "version" => Raven.sys_command("ruby -v")
+          :name => RbConfig::CONFIG["ruby_install_name"],
+          :version => Raven.sys_command("ruby -v")
         }
       end
     end

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -68,8 +68,6 @@ module Raven
       @user = @context.user.merge(@user) # TODO: contexts
       @extra = @context.extra.merge(@extra) # TODO: contexts
       @tags = @configuration.tags.merge(@context.tags).merge(@tags) # TODO: contexts
-      @server_os = @context.server_os # TODO: contexts
-      @runtime = @context.runtime # TODO: contexts
 
       # Some type coercion
       @timestamp  = @timestamp.strftime('%Y-%m-%dT%H:%M:%S') if @timestamp.is_a?(Time)
@@ -248,11 +246,7 @@ module Raven
         :time_spent => @time_spent,
         :level => @level,
         :platform => PLATFORM,
-        :sdk => SDK,
-        :contexts => {
-          :server_os => @server_os,
-          :runtime => @runtime
-        }
+        :sdk => SDK
       }
 
       data[:logger] = @logger if @logger

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -51,7 +51,7 @@ describe Raven::Event do
     end
 
     it 'has extra data' do
-      expect(hash[:extra]).to eq('my_custom_variable' => 'value')
+      expect(hash[:extra]["my_custom_variable"]).to eq('value')
     end
 
     it 'has platform' do
@@ -63,11 +63,11 @@ describe Raven::Event do
     end
 
     it 'has server os' do
-      expect(hash[:contexts][:server_os].keys).to eq(%w(name version build kernel_version))
+      expect(hash[:extra][:server][:os].keys).to eq([:name, :version, :build, :kernel_version])
     end
 
     it 'has runtime' do
-      expect(hash[:contexts][:runtime]["version"]).to match(/ruby/)
+      expect(hash[:extra][:server][:runtime][:version]).to match(/ruby/)
     end
   end
 
@@ -128,8 +128,8 @@ describe Raven::Event do
     end
 
     it "merges extra data" do
-      expect(hash[:extra]).to eq('key' => 'value',
-                                 'my_custom_variable' => 'value')
+      expect(hash[:extra]['key']).to eq('value')
+      expect(hash[:extra]['my_custom_variable']).to eq('value')
     end
   end
 
@@ -309,9 +309,9 @@ describe Raven::Event do
     end
 
     it 'prioritizes event context over request context' do
-      expect(hash[:extra]).to eq('context_event_key' => 'event_value',
-                                 'context_key' => 'context_value',
-                                 'event_key' => 'event_value')
+      expect(hash[:extra]['context_event_key']).to eq('event_value')
+      expect(hash[:extra]['context_key']).to eq('context_value')
+      expect(hash[:extra]['event_key']).to eq('event_value')
     end
   end
 
@@ -333,9 +333,9 @@ describe Raven::Event do
     end
 
     it 'prioritizes event context over request context' do
-      expect(hash[:extra]).to eq('context_event_key' => 'event_value',
-                                 'context_key' => 'context_value',
-                                 'event_key' => 'event_value')
+      expect(hash[:extra]['context_event_key']).to eq('event_value')
+      expect(hash[:extra]['context_key']).to eq('context_value')
+      expect(hash[:extra]['event_key']).to eq('event_value')
     end
   end
 


### PR DESCRIPTION
Unfortunately this won't really integrate well with Sentry, but
its better than not reporting anything. Waiting on upstream to
fix the contexts hash.


Closes #583 