### PR TITLE
Allows faraday 0.10.x

### DIFF
--- a/sentry-raven.gemspec
+++ b/sentry-raven.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.license = 'Apache-2.0'
   gem.required_ruby_version = '>= 1.9.0'
 
-  gem.add_dependency "faraday", ">= 0.7.6", "< 0.10.x"
+  gem.add_dependency "faraday", ">= 0.7.6", "< 1.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rubocop", "~> 0.41.1"


### PR DESCRIPTION
Strict dependency versions are considered harmful. Semantic versioning style seems better.

See https://github.com/lostisland/faraday/releases for faraday change logs.