### PR TITLE
Allow some fields to be excluded from sanitization

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -96,6 +96,9 @@ module Raven
     # a hash key, will be censored and not sent to Sentry.
     attr_accessor :sanitize_fields
 
+    # Array of fields that should never be sanitized.
+    attr_accessor :excluded_fields
+
     # Sanitize additional HTTP headers - only Authorization is removed by default.
     attr_accessor :sanitize_http_headers
 
@@ -188,6 +191,7 @@ module Raven
       self.release = detect_release
       self.sanitize_credit_cards = true
       self.sanitize_fields = []
+      self.excluded_fields = []
       self.sanitize_http_headers = []
       self.send_modules = true
       self.server = ENV['SENTRY_DSN'] if ENV['SENTRY_DSN']

--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -6,17 +6,21 @@ module Raven
     DEFAULT_FIELDS = %w(authorization password passwd secret ssn social(.*)?sec).freeze
     CREDIT_CARD_RE = /^(?:\d[ -]*?){13,16}$/
 
-    attr_accessor :sanitize_fields, :sanitize_credit_cards
+    attr_accessor :sanitize_fields, :sanitize_credit_cards, :excluded_fields
 
     def initialize(client)
       super
       self.sanitize_fields = client.configuration.sanitize_fields
       self.sanitize_credit_cards = client.configuration.sanitize_credit_cards
+      self.excluded_fields = client.configuration.excluded_fields
     end
 
     def process(value)
       return value if value.frozen?
-      value.each_with_object(value) { |(k, v), memo| memo[k] = sanitize(k, v) }
+      value.each_with_object(value) do |(k, v), memo|
+        next if excluded_fields.include?(k.to_s)
+        memo[k] = sanitize(k, v)
+      end
     end
 
     def sanitize(k, v)

--- a/spec/raven/processors/sanitizedata_processor_spec.rb
+++ b/spec/raven/processors/sanitizedata_processor_spec.rb
@@ -5,6 +5,7 @@ describe Raven::Processor::SanitizeData do
     @client = double("client")
     allow(@client).to receive_message_chain(:configuration, :sanitize_fields) { ['user_field'] }
     allow(@client).to receive_message_chain(:configuration, :sanitize_credit_cards) { true }
+    allow(@client).to receive_message_chain(:configuration, :excluded_fields) { ['safe_authorization_field'] }
     @processor = Raven::Processor::SanitizeData.new(@client)
   end
 
@@ -32,7 +33,8 @@ describe Raven::Processor::SanitizeData do
           :ssn => '123-45-6789', # test symbol handling
           'social_security_number' => 123456789,
           'user_field' => 'user',
-          'user_field_foo' => 'hello'
+          'user_field_foo' => 'hello',
+          'safe_authorization_field' => 'safe_data'
         }
       }
     }
@@ -50,6 +52,7 @@ describe Raven::Processor::SanitizeData do
     expect(vars["social_security_number"]).to eq(Raven::Processor::SanitizeData::INT_MASK)
     expect(vars["user_field"]).to eq(Raven::Processor::SanitizeData::STRING_MASK)
     expect(vars["user_field_foo"]).to eq('hello')
+    expect(vars["safe_authorization_field"]).to eq('safe_data')
   end
 
   it 'should filter json data' do


### PR DESCRIPTION
That's a feature we need for our project.
In our project, I have monkey-patch `Configuration` and created a new processor, but I think this option could be in the original processor.