### PR TITLE
Various logger improvements

### DIFF
--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -32,7 +32,7 @@ module Raven
         return
       end
 
-      configuration.logger.debug "Sending event #{event[:event_id]} to Sentry"
+      configuration.logger.info "Sending event #{event[:event_id]} to Sentry"
 
       content_type, encoded_data = encode(event)
 

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -1,4 +1,3 @@
-require 'logger'
 require 'uri'
 
 module Raven
@@ -274,6 +273,7 @@ module Raven
     alias sending_allowed? capture_allowed?
 
     def error_messages
+      @errors = [errors[0]] + errors[1..-1].map(&:downcase) # fix case of all but first
       errors.join(", ")
     end
 
@@ -328,6 +328,7 @@ module Raven
     end
 
     def valid?
+      return ["DSN not set"] unless server
       err = %w(server host path public_key secret_key project_id).map do |key|
         "No #{key} specified" unless public_send(key)
       end

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -96,11 +96,11 @@ module Raven
         configuration = options[:configuration] || Raven.configuration
         if exc.is_a?(Raven::Error)
           # Try to prevent error reporting loops
-          configuration.logger.info "Refusing to capture Raven error: #{exc.inspect}"
+          configuration.logger.debug "Refusing to capture Raven error: #{exc.inspect}"
           return nil
         end
         if configuration[:excluded_exceptions].any? { |x| get_exception_class(x) === exc }
-          configuration.logger.info "User excluded error: #{exc.inspect}"
+          configuration.logger.debug "User excluded error: #{exc.inspect}"
           return nil
         end
 

--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -34,8 +34,8 @@ module Raven
 
     config.after_initialize do
       Raven.configure do |config|
-        config.logger ||= ::Rails.logger
         config.project_root ||= ::Rails.root
+        config.logger ||= ::Rails.logger
         config.release ||= config.detect_release # if project_root has changed, need to re-check
       end
 

--- a/lib/raven/logger.rb
+++ b/lib/raven/logger.rb
@@ -8,6 +8,7 @@ module Raven
 
     def initialize(*)
       super
+      @level = ::Logger::INFO
       original_formatter = ::Logger::Formatter.new
       @default_formatter = proc do |severity, datetime, _progname, msg|
         msg = "#{LOG_PREFIX}#{msg}"


### PR DESCRIPTION
Fixes #607.

End result is that "Not sending due to X" errors are not displayed unless you edit Raven's log level. We still log by default on sending an error and upon startup ("ready to catch" message).