### PR TITLE
Limit exception messages to 10k chars

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -106,7 +106,7 @@ module Raven
 
         new(options) do |evt|
           evt.configuration = configuration
-          evt.message = "#{exc.class}: #{exc.message}"
+          evt.message = "#{exc.class}: #{exc.message}".byteslice(0...10_000) # Messages limited to 10kb
           evt.level = options[:level] || :error
 
           add_exception_interface(evt, exc)


### PR DESCRIPTION
A customer reported logs of 413s when trying to send a massive payload.

The log line is something like this:

```
Failed to submit event: Module::DelegationError: RecommendationCell#recommendation_card_title delegated to recommendation.recommendation_card_title, but recommendation is nil: #<RecommendationCell:0x000 @model=#<ContentfulProduct:0x000 @id="xxx", @content_type="product", @fields={"formulae"=>["xxx", "xxx", "xxx", "xxx", "xxx",  ...
```

for well over 65k. The data we have is truncated, so it continues on beyond that for an unknown length.

From glancing at code, this appears to be where this is coming from. Unsure if there are other paths that would generated an unbounded message size like this.

This is being done inside `from_message`, so seems logical to also do here.