### PR TITLE
Handle JRuby uri:classloader filenames in backtraces

### DIFF
--- a/lib/raven/backtrace.rb
+++ b/lib/raven/backtrace.rb
@@ -6,7 +6,7 @@ module Raven
     # Handles backtrace parsing line by line
     class Line
       # regexp (optional leading X: on windows, or JRuby9000 class-prefix)
-      RUBY_INPUT_FORMAT = %r/
+      RUBY_INPUT_FORMAT = /
         ^ \s* (?: [a-zA-Z]: | uri:classloader: )? ([^:]+ | <.*>):
         (\d+)
         (?: :in \s `([^']+)')?$

--- a/lib/raven/backtrace.rb
+++ b/lib/raven/backtrace.rb
@@ -5,8 +5,19 @@ module Raven
   class Backtrace
     # Handles backtrace parsing line by line
     class Line
-      # regexp (optionnally allowing leading X: for windows support)
-      RUBY_INPUT_FORMAT = /^((?:[a-zA-Z]:)?[^:]+|<.*>):(\d+)(?::in `([^']+)')?$/
+      # regexp (optional leading X: or windows or JRuby9000 class-prefix)
+      RUBY_INPUT_FORMAT = %r{
+        ^ \s* (?: [a-zA-Z]: | uri:classloader: )? ([^:]+ | <.*>):
+        (\d+)
+        (?: :in \s `([^']+)')?$
+      }x
+
+      J9K_INPUT_FORMAT = %r{
+        ^ \s* at \s RUBY.block \s in \s ([^(]+) \( # method name
+        uri:classloader: ?                         # jar prefix
+        (.*):                                      # file
+        (\d)+ \)                                   # line number
+      }x
 
       # org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
       JAVA_INPUT_FORMAT = /^(.+)\.([^\.]+)\(([^\:]+)\:(\d+)\)$/
@@ -27,13 +38,16 @@ module Raven
       # @param [String] unparsed_line The raw line from +caller+ or some backtrace
       # @return [Line] The parsed backtrace line
       def self.parse(unparsed_line)
-        ruby_match = unparsed_line.match(RUBY_INPUT_FORMAT)
-        if ruby_match
+        if (ruby_match = unparsed_line.match(RUBY_INPUT_FORMAT))
           _, file, number, method = ruby_match.to_a
+          file.sub!(/\.class$/, ".rb")
           module_name = nil
-        else
-          java_match = unparsed_line.match(JAVA_INPUT_FORMAT)
+        elsif (java_match = unparsed_line.match(JAVA_INPUT_FORMAT))
           _, module_name, method, file, number = java_match.to_a
+        elsif (j9k_match = unparsed_line.match(J9K_INPUT_FORMAT))
+          _, method, file, number = j9k_match.to_a
+          file.sub!(/\.class$/, ".rb")
+          module_name = nil
         end
         new(file, number, method, module_name)
       end


### PR DESCRIPTION
When we updated our app from JRuby 1.7 to JRuby9000 9.1.5.0 sentry stopped working.

This fixes it for us, but any time I touch a regex I assume I have made a mistake,
so I am not 100% confident I didn't break parsing of error messages that used
to parse correctly.