### PR TITLE
Fix format message if params is empty

### DIFF
--- a/lib/raven/interfaces/message.rb
+++ b/lib/raven/interfaces/message.rb
@@ -10,7 +10,7 @@ module Raven
     end
 
     def unformatted_message
-      params.nil? ? message : message % params
+      Array(params).empty? ? message : message % params
     end
 
     def self.sentry_alias

--- a/spec/raven/interface_spec.rb
+++ b/spec/raven/interface_spec.rb
@@ -30,4 +30,8 @@ describe Raven::MessageInterface do
     interface = Raven::MessageInterface.new(:params => nil, :message => "test '%'")
     expect(interface.unformatted_message).to eq("test '%'")
   end
+  it "supports invalid format string message when params is empty" do
+    interface = Raven::MessageInterface.new(:message => "test '%'")
+    expect(interface.unformatted_message).to eq("test '%'")
+  end
 end


### PR DESCRIPTION
Fixes #570 and #624

#570 is support `params` is not defined.
This fixes support `params` is not specified, using default parameter(empty array) and nil.