### PR TITLE
Don't assume exception has a response

### DIFF
--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -29,7 +29,9 @@ module Raven
         end
       rescue Faraday::ClientError => ex
         error_info = ex.message
-        error_info += " Error in headers is: #{ex.response[:headers]['x-sentry-error']}" if ex.response[:headers]['x-sentry-error']
+        if ex.response && ex.response[:headers]['x-sentry-error']
+          error_info += " Error in headers is: #{ex.response[:headers]['x-sentry-error']}"
+        end
         raise Raven::Error, error_info
       end
 


### PR DESCRIPTION
I was trying out the sample code and getting a really strange error:
```
irb(main):003:0> Raven.capture { 1/0 }
I, [2017-01-30T14:50:13.002654 #63295]  INFO -- sentry: ** [Raven] Sending event b9824a076643428786eebb7d96378993 to Sentry
E, [2017-01-30T14:50:13.401824 #63295] ERROR -- sentry: ** [Raven] Unable to record event with remote Sentry server (NoMethodError - undefined method `[]' for nil:NilClass)
E, [2017-01-30T14:50:13.401957 #63295] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/transports/http.rb:32:in `rescue in send_event'
E, [2017-01-30T14:50:13.401989 #63295] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/transports/http.rb:18:in `send_event'
E, [2017-01-30T14:50:13.402008 #63295] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/client.rb:40:in `send_event'
E, [2017-01-30T14:50:13.402025 #63295] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:81:in `send_event'
E, [2017-01-30T14:50:13.402040 #63295] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:126:in `capture_type'
E, [2017-01-30T14:50:13.402056 #63295] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:97:in `rescue in capture'
E, [2017-01-30T14:50:13.402071 #63295] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:92:in `capture'
E, [2017-01-30T14:50:13.402086 #63295] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/2.3.0/forwardable.rb:189:in `capture'
E, [2017-01-30T14:50:13.402106 #63295] ERROR -- sentry: ** [Raven] (irb):3:in `irb_binding'
E, [2017-01-30T14:50:13.402121 #63295] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/2.3.0/irb/workspace.rb:87:in `eval'
E, [2017-01-30T14:50:13.402136 #63295] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/2.3.0/irb/workspace.rb:87:in `evaluate'
E, [2017-01-30T14:50:13.402155 #63295] ERROR -- sentry: ** [Raven] Failed to submit event: ZeroDivisionError: divided by 0
ZeroDivisionError: divided by 0
    from (irb):3:in `/'
    from (irb):3:in `block in irb_binding'
    from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:93:in `capture'
    from (irb):3
    from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/console.rb:65:in `start'
    from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/console_helper.rb:9:in `start'
    from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:78:in `console'
    from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
    from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands.rb:18:in `<top (required)>'
    from bin/rails:4:in `require'
    from bin/rails:4:in `<main>'
irb(main):004:0> 
```
I traced it down to the `Raven::Transports::HTTP` error handler. The underlying bug is that the SSL verification fails but the wrapped OpenSSL exceptions don't have a response:

    #<Faraday::SSLError wrapped=#<OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed>>

Adding the extra check gets me an error that I can start troubleshooting:
```
irb(main):001:0> Raven.capture { 1/0 }
I, [2017-01-30T23:15:18.948759 #4498]  INFO -- sentry: ** [Raven] Sending event b9c8e4a11a624e6cb3a48da6c8b4133f to Sentry
E, [2017-01-30T23:15:19.338223 #4498] ERROR -- sentry: ** [Raven] Unable to record event with remote Sentry server (Raven::Error - SSL_connect returned=1 errno=0 state=error: certificate verify failed)
E, [2017-01-30T23:15:19.338362 #4498] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/transports/http.rb:35:in `rescue in send_event'
E, [2017-01-30T23:15:19.338392 #4498] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/transports/http.rb:18:in `send_event'
E, [2017-01-30T23:15:19.338411 #4498] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/client.rb:40:in `send_event'
E, [2017-01-30T23:15:19.338428 #4498] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:81:in `send_event'
E, [2017-01-30T23:15:19.338444 #4498] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:126:in `capture_type'
E, [2017-01-30T23:15:19.338460 #4498] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:97:in `rescue in capture'
E, [2017-01-30T23:15:19.338479 #4498] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:92:in `capture'
E, [2017-01-30T23:15:19.338495 #4498] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/2.3.0/forwardable.rb:189:in `capture'
E, [2017-01-30T23:15:19.338510 #4498] ERROR -- sentry: ** [Raven] (irb):1:in `irb_binding'
E, [2017-01-30T23:15:19.338525 #4498] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/2.3.0/irb/workspace.rb:87:in `eval'
E, [2017-01-30T23:15:19.338541 #4498] ERROR -- sentry: ** [Raven] /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/2.3.0/irb/workspace.rb:87:in `evaluate'
E, [2017-01-30T23:15:19.338561 #4498] ERROR -- sentry: ** [Raven] Failed to submit event: ZeroDivisionError: divided by 0
ZeroDivisionError: divided by 0
	from (irb):1:in `/'
	from (irb):1:in `block in irb_binding'
	from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:93:in `capture'
	from (irb):1
	from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/console.rb:65:in `start'
	from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/console_helper.rb:9:in `start'
	from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:78:in `console'
	from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
	from /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/railties-5.0.0.1/lib/rails/commands.rb:18:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
irb(main):002:0>
```

Follow up to #585.