### PR TITLE
Don't try to log non-existing HTTP headers.

### DIFF
--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -29,7 +29,9 @@ module Raven
         end
       rescue Faraday::ClientError => ex
         error_info = ex.message
-        error_info += " Error in headers is: #{ex.response[:headers]['x-sentry-error']}" if ex.response[:headers]['x-sentry-error']
+        unless ex.response.nil?
+          error_info += " Error in headers is: #{ex.response[:headers]['x-sentry-error']}" if ex.response[:headers]['x-sentry-error']
+        end
         raise Raven::Error, error_info
       end
 


### PR DESCRIPTION
I found this in the logs and Raven isn't able to transmit exceptions until I manually restart the app:

```
[Raven] Unable to record event with remote Sentry server (NoMethodError - undefined method `[]' for nil:NilClass)
[Raven] /usr/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/transports/http.rb:32:in `rescue in send_event'
[Raven] /usr/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/transports/http.rb:18:in `send_event'
[Raven] /usr/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/client.rb:40:in `send_event'
[Raven] /usr/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:81:in `send_event'
[Raven] /usr/lib/ruby/gems/2.3.0/gems/sentry-raven-2.3.0/lib/raven/instance.rb:126:in `capture_type'
[Raven] /usr/lib/ruby/2.3.0/forwardable.rb:184:in `capture_exception'
```

I think this is caused by [this line](https://github.com/getsentry/raven-ruby/blob/v2.3.0/lib/raven/transports/http.rb#L32):

```ruby
rescue Faraday::ClientError => ex
  error_info = ex.message
  error_info += " Error in headers is: #{ex.response[:headers]['x-sentry-error']}" if ex.response[:headers]['x-sentry-error']
  raise Raven::Error, error_info
end
```

If a network error occurs the response might by empty.