### PR TITLE
Increase truncation limit on handler to 1000

### DIFF
--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -24,10 +24,10 @@ module Delayed
               }
             }
             # last_error can be nil
-            extra[:last_error] = job.last_error[0...100] if job.last_error
+            extra[:last_error] = job.last_error[0...1000] if job.last_error
             # handlers are YAML objects in strings, we definitely can't
             # report all of that or the event will get truncated randomly
-            extra[:handler] = job.handler[0...255] if job.handler
+            extra[:handler] = job.handler[0...1000] if job.handler
 
             if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
               extra[:active_job] = job.payload_object.job_data

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -27,7 +27,7 @@ module Delayed
             extra[:last_error] = job.last_error[0...100] if job.last_error
             # handlers are YAML objects in strings, we definitely can't
             # report all of that or the event will get truncated randomly
-            extra[:handler] = job.handler[0...100] if job.handler
+            extra[:handler] = job.handler[0...255] if job.handler
 
             if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
               extra[:active_job] = job.payload_object.job_data


### PR DESCRIPTION
I am trying to debug a Job error. The problem is that Sentry is truncating the "handler" under "Additional Data". What I see in Sentry is
```
--- !ruby/object:Delayed::PerformableMailer
object: !ruby/class 'GeneralMailer'
method_name: :generi
```

This requires me to go digging outside of Sentry to find the full handler to get the ID of the troublesome entry (in args)
```
--- !ruby/object:Delayed::PerformableMailer
object: !ruby/class 'GeneralMailer'
method_name: :generic_message
args:
- 305294"
```