### PR TITLE
Temporarily accept string keys in processors.

### DIFF
--- a/lib/raven/processor/cookies.rb
+++ b/lib/raven/processor/cookies.rb
@@ -1,16 +1,26 @@
 module Raven
   class Processor::Cookies < Processor
     def process(data)
-      if data[:request]
-        # Remove possibly sensitive cookies
-        data[:request][:cookies] = STRING_MASK if data[:request][:cookies]
-
-        if data[:request][:headers] && data[:request][:headers]["Cookie"]
-          data[:request][:headers]["Cookie"] = STRING_MASK
-        end
-      end
+      process_if_symbol_keys(data) if data[:request]
+      process_if_string_keys(data) if data["request"]
 
       data
+    end
+
+    private
+
+    def process_if_symbol_keys(data)
+      data[:request][:cookies] = STRING_MASK if data[:request][:cookies]
+
+      return unless data[:request][:headers] && data[:request][:headers]["Cookie"]
+      data[:request][:headers]["Cookie"] = STRING_MASK
+    end
+
+    def process_if_string_keys(data)
+      data["request"]["cookies"] = STRING_MASK if data["request"]["cookies"]
+
+      return unless data["request"]["headers"] && data["request"]["headers"]["Cookie"]
+      data["request"]["headers"]["Cookie"] = STRING_MASK
     end
   end
 end

--- a/lib/raven/processor/http_headers.rb
+++ b/lib/raven/processor/http_headers.rb
@@ -10,16 +10,29 @@ module Raven
     end
 
     def process(data)
-      if data[:request] && data[:request][:headers]
-        data[:request][:headers].keys.select { |k| fields_re.match(k.to_s) }.each do |k|
-          data[:request][:headers][k] = STRING_MASK
-        end
-      end
+      process_if_symbol_keys(data) if data[:request]
+      process_if_string_keys(data) if data["request"]
 
       data
     end
 
     private
+
+    def process_if_symbol_keys(data)
+      return unless data[:request][:headers]
+
+      data[:request][:headers].keys.select { |k| fields_re.match(k.to_s) }.each do |k|
+        data[:request][:headers][k] = STRING_MASK
+      end
+    end
+
+    def process_if_string_keys(data)
+      return unless data["request"]["headers"]
+
+      data["request"]["headers"].keys.select { |k| fields_re.match(k) }.each do |k|
+        data["request"]["headers"][k] = STRING_MASK
+      end
+    end
 
     def matches_regexes?(k)
       fields_re.match(k.to_s)

--- a/lib/raven/processor/post_data.rb
+++ b/lib/raven/processor/post_data.rb
@@ -1,11 +1,22 @@
 module Raven
   class Processor::PostData < Processor
     def process(data)
-      if data[:request] && data[:request][:method] == "POST"
-        data[:request][:data] = STRING_MASK # Remove possibly sensitive POST data
-      end
+      process_if_symbol_keys(data) if data[:request]
+      process_if_string_keys(data) if data["request"]
 
       data
+    end
+
+    private
+
+    def process_if_symbol_keys(data)
+      return unless data[:request][:method] == "POST"
+      data[:request][:data] = STRING_MASK
+    end
+
+    def process_if_string_keys(data)
+      return unless data["request"]["method"] == "POST"
+      data["request"]["data"] = STRING_MASK
     end
   end
 end

--- a/lib/raven/processor/removestacktrace.rb
+++ b/lib/raven/processor/removestacktrace.rb
@@ -1,13 +1,24 @@
 module Raven
   class Processor::RemoveStacktrace < Processor
-    def process(value)
-      if value[:exception]
-        value[:exception][:values].map do |single_exception|
-          single_exception.delete(:stacktrace) if single_exception[:stacktrace]
-        end
-      end
+    def process(data)
+      process_if_symbol_keys(data) if data[:exception]
+      process_if_string_keys(data) if data["exception"]
 
-      value
+      data
+    end
+
+    private
+
+    def process_if_symbol_keys(data)
+      data[:exception][:values].map do |single_exception|
+        single_exception.delete(:stacktrace) if single_exception[:stacktrace]
+      end
+    end
+
+    def process_if_string_keys(data)
+      data["exception"]["values"].map do |single_exception|
+        single_exception.delete("stacktrace") if single_exception["stacktrace"]
+      end
     end
   end
 end

--- a/spec/raven/processors/cookies_spec.rb
+++ b/spec/raven/processors/cookies_spec.rb
@@ -9,7 +9,7 @@ describe Raven::Processor::Cookies do
   end
 
   it 'should remove cookies' do
-    data = {
+    test_data = {
       :request => {
         :headers => {
           "Cookie" => "_sentry-testapp_session=SlRKVnNha2Z",
@@ -20,11 +20,31 @@ describe Raven::Processor::Cookies do
       }
     }
 
-    result = @processor.process(data)
+    result = @processor.process(test_data)
 
     expect(result[:request][:cookies]).to eq("********")
     expect(result[:request][:headers]["Cookie"]).to eq("********")
     expect(result[:request][:some_other_data]).to eq("still_here")
     expect(result[:request][:headers]["AnotherHeader"]).to eq("still_here")
+  end
+
+  it 'should remove cookies even if keys are strings' do
+    test_data = {
+      "request" => {
+        "headers" => {
+          "Cookie" => "_sentry-testapp_session=SlRKVnNha2Z",
+          "AnotherHeader" => "still_here"
+        },
+        "cookies" => "_sentry-testapp_session=SlRKVnNha2Z",
+        "some_other_data" => "still_here"
+      }
+    }
+
+    result = @processor.process(test_data)
+
+    expect(result["request"]["cookies"]).to eq("********")
+    expect(result["request"]["headers"]["Cookie"]).to eq("********")
+    expect(result["request"]["some_other_data"]).to eq("still_here")
+    expect(result["request"]["headers"]["AnotherHeader"]).to eq("still_here")
   end
 end

--- a/spec/raven/processors/http_headers_spec.rb
+++ b/spec/raven/processors/http_headers_spec.rb
@@ -38,4 +38,20 @@ describe Raven::Processor::HTTPHeaders do
     expect(result[:request][:headers]["User-Defined-Header"]).to eq("********")
     expect(result[:request][:headers]["AnotherHeader"]).to eq("still_here")
   end
+
+  it "should remove headers even if the keys are strings" do
+    data = {
+      "request" => {
+        "headers" => {
+          "Authorization" => "dontseeme",
+          "AnotherHeader" => "still_here"
+        }
+      }
+    }
+
+    result = @processor.process(data)
+
+    expect(result["request"]["headers"]["Authorization"]).to eq("********")
+    expect(result["request"]["headers"]["AnotherHeader"]).to eq("still_here")
+  end
 end

--- a/spec/raven/processors/post_data_spec.rb
+++ b/spec/raven/processors/post_data_spec.rb
@@ -37,4 +37,19 @@ describe Raven::Processor::PostData do
 
     expect(result[:request][:data]).to eq("sensitive_stuff" => "TOP_SECRET-GAMMA")
   end
+
+  it 'should remove post data when HTTP method is POST and keys are strings' do
+    data = {
+      "request" => {
+        "method" => "POST",
+        "data" => {
+          "sensitive_stuff" => "TOP_SECRET-GAMMA"
+        }
+      }
+    }
+
+    result = @processor.process(data)
+
+    expect(result["request"]["data"]).to eq("********")
+  end
 end

--- a/spec/raven/processors/removestacktrace_spec.rb
+++ b/spec/raven/processors/removestacktrace_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'raven/processor/removestacktrace'
+require 'active_support/core_ext/hash/keys'
 
 describe Raven::Processor::RemoveStacktrace do
   before do
@@ -41,5 +42,14 @@ describe Raven::Processor::RemoveStacktrace do
       expect(result[:exception][:values][1][:stacktrace]).to eq(nil)
       expect(result[:exception][:values][2][:stacktrace]).to eq(nil)
     end
+  end
+
+  it 'should remove stacktraces even when keys are strings' do
+    data = Raven::Event.capture_exception(build_exception).to_hash.deep_stringify_keys
+
+    expect(data["exception"]["values"][0]["stacktrace"]).to_not eq(nil)
+    result = @processor.process(data)
+
+    expect(result["exception"]["values"][0]["stacktrace"]).to eq(nil)
   end
 end


### PR DESCRIPTION
Close #622

This will be removed in 3.0, when all event hashes will be expected
to contain string keys.