### PR TITLE
Use :job instead of "job" and prefer "wrapped" over "class"

### DIFF
--- a/lib/raven/integrations/sidekiq.rb
+++ b/lib/raven/integrations/sidekiq.rb
@@ -45,7 +45,7 @@ module Raven
     # this will change in the future:
     # https://github.com/mperham/sidekiq/pull/3161
     def culprit_from_context(context)
-      classname = (context["class"] || (context["job"] && context["job"]["class"]))
+      classname = (context["class"] || (context[:job] && (context[:job]["wrapped"] || context[:job]["class"])))
       if classname
         "Sidekiq/#{classname}"
       elsif context["event"]


### PR DESCRIPTION
I took a stab at https://github.com/getsentry/raven-ruby/issues/630 myself and noticed that `"job"` key should have been `:job`, which explains why we were getting the culprit

```ruby
Sidekiq
```

(implying `classname == nil`) instead of the value of `context[:job]["class"]`, which is

```ruby
ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper
```

for wrapped jobs.