### PR TITLE
Clear stale breadcrumbs and context after Sidekiq jobs

### DIFF
--- a/spec/raven/integrations/sidekiq_spec.rb
+++ b/spec/raven/integrations/sidekiq_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'raven/integrations/sidekiq'
 
-describe Raven::Sidekiq do
+describe Raven::SidekiqErrorHandler do
   before(:all) do
     Raven.configure do |config|
       config.dsn = 'dummy://12345:67890@sentry.localdomain:3000/sentry/42'


### PR DESCRIPTION
The error handler is only called after an exception so the context (specifically breadcrumbs) will carry over from previous jobs that completed successfully.

Fixes #636

I'm not sure this is exactly the way the maintainers would want to approach it but it seems to be working better for me. I'm not using ActiveJob so I don't know if that would play into this.

You can test this out by creating two new sidekiq jobs:
```
bundle exec rails g sidekiq:worker Happy
bundle exec rails g sidekiq:worker Sad
```
Then fill in some basic processing logic to have one record breadcrumbs and context:
```rb
class HappyWorker
  include Sidekiq::Worker

  def perform(*args)
    Raven.breadcrumbs.record do |crumb|
      crumb.message = "I'm happy!"
    end
    Raven.tags_context mood: 'happy'
  end
end
```
And the other just raise an exception and doesn't retry
```rb
class SadWorker
  include Sidekiq::Worker

  sidekiq_options :retry => false

  def perform(*args)
    raise "I'm sad!"
  end
end
```

Start up sidekiq with a single thread (so we don't have to worry about which worker picks up which job):
```
bundle exec sidekiq -c 1
```

Open up a rails console in another terminal window and queue up a couple of jobs:
```
HappyWorker.perform_async
HappyWorker.perform_async
SadWorker.perform_async
```

On the master branch the Sentry issue from `SadWorker` will include the breadcrumbs and tags from the `HappyWorker`:
![runtimeerror__i_m_sad_](https://cloud.githubusercontent.com/assets/68750/23316262/ef4e7c22-fa86-11e6-8545-09650a73e3da.png)
