### PR TITLE
Use Rails logger by default again

### DIFF
--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -32,10 +32,13 @@ module Raven
       end
     end
 
+    config.before_initialize do
+      Raven.configuration.logger = ::Rails.logger
+    end
+
     config.after_initialize do
       Raven.configure do |config|
         config.project_root ||= ::Rails.root
-        config.logger ||= ::Rails.logger
         config.release ||= config.detect_release # if project_root has changed, need to re-check
       end
 

--- a/spec/raven/integrations/rails_spec.rb
+++ b/spec/raven/integrations/rails_spec.rb
@@ -6,14 +6,20 @@ require "raven/integrations/rails"
 
 describe TestApp, :type => :request do
   before(:all) do
-    Raven.configure do |config|
+    @original_configuration = Raven.configuration
+
+    Raven.configuration = Raven::Configuration.new.tap do |config|
       config.dsn = 'dummy://12345:67890@sentry.localdomain:3000/sentry/42'
       config.encoding = 'json'
-      config.logger = false
     end
+
     Rails.logger = Logger.new(nil)
     Rails.env = "production"
     TestApp.initialize!
+  end
+
+  after(:all) do
+    Raven.configuration = @original_configuration
   end
 
   after(:each) do


### PR DESCRIPTION
Before https://github.com/getsentry/raven-ruby/pull/599, `Raven.configuration.logger` was nil if there was no logger configured; now it's always an instance of `Raven::Logger`. This means that the `||=` assignment in the railtie no longer has any effect.

If we unconditionally set the logger in a `before_initialize` hook, apps will still be able to configure their own logger in an initializer, but the Rails logger will be used by default again if they don't.

There's an existing test which covers this behaviour, but the logger was being set to false before it ran, which doesn't accurately reflect the default configuration any more. Instead of trying to reset the logger before the test, we can temporarily swap in a new configuration object.