### PR TITLE
Allow for customisation of the Faraday Adapter

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -37,6 +37,10 @@ module Raven
     # The Faraday adapter to be used. Will default to Net::HTTP when not set.
     attr_accessor :http_adapter
 
+    # A Proc yeilding the faraday builder allowing for further configuration
+    # of the faraday adapter
+    attr_accessor :faraday_builder
+
     # You may provide your own LineCache for matching paths with source files.
     # This may be useful if you need to get source code from places other than
     # the disk. See Raven::LineCache for the required interface you must implement.

--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -48,6 +48,7 @@ module Raven
           :url => configuration[:server],
           :ssl => ssl_configuration
         ) do |builder|
+          configuration.faraday_builder.call(builder) if configuration.faraday_builder
           builder.response :raise_error
           builder.adapter(*adapter)
         end

--- a/spec/raven/transports/http_spec.rb
+++ b/spec/raven/transports/http_spec.rb
@@ -46,4 +46,17 @@ describe Raven::Transports::HTTP do
 
     stubs.verify_stubbed_calls
   end
+
+  it 'allows to customise faraday' do
+    builder = spy('faraday_builder')
+    expect(Faraday).to receive(:new).and_yield(builder)
+
+    Raven.configure do |config|
+      config.faraday_builder = proc { |b| b.request :instrumentation }
+    end
+
+    Raven.client.send(:transport)
+
+    expect(builder).to have_received(:request).with(:instrumentation)
+  end
 end


### PR DESCRIPTION
**CHANGES:**

We wanted to customise the faraday adapter which currently didn't seem possible.
This allows to provide a custom proc that is then called with the Faraday builder when creating the HTTP connection