### PR TITLE
Change SDK name in JSON to raven-ruby.

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -21,7 +21,7 @@ module Raven
     BACKTRACE_RE = /^(.+?):(\d+)(?::in `(.+?)')?$/
 
     PLATFORM = "ruby".freeze
-    SDK = { "name" => "sentry-raven", "version" => Raven::VERSION }.freeze
+    SDK = { "name" => "raven-ruby", "version" => Raven::VERSION }.freeze
 
     attr_accessor :id, :timestamp, :time_spent, :level, :logger,
                   :culprit, :server_name, :release, :modules, :extra, :tags,

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -60,7 +60,7 @@ describe Raven::Event do
     end
 
     it 'has SDK' do
-      expect(hash[:sdk]).to eq("name" => "sentry-raven", "version" => Raven::VERSION)
+      expect(hash[:sdk]).to eq("name" => "raven-ruby", "version" => Raven::VERSION)
     end
 
     it 'has server os' do


### PR DESCRIPTION
We use `raven-java` for Java, etc. The SDK field is used server-side for things like https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py#L1135

Not to self, we should (maybe) put this in `DEPRECATED_SDKS` to redirect if we change it: https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py#L1150