### PR TITLE
Travis: Use latest stable - jruby-9.1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ matrix:
     - rvm: jruby-1.7.26
       env: JRUBY_OPTS="--dev"
       gemfile: gemfiles/rails42.gemfile
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.8.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
       gemfile: gemfiles/rails42.gemfile
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.8.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"
       gemfile: gemfiles/rails5.gemfile
   allow_failures:


### PR DESCRIPTION
This PR updates JRuby to latest stable.

Thanks for keeping JRuby in your test suite!