### PR TITLE
Fix wrong Raven.user_context usage breaking event sending

### DIFF
--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -171,7 +171,16 @@ module Raven
     # @example
     #   Raven.user_context('id' => 1, 'email' => 'foo@example.com')
     def user_context(options = nil)
-      context.user = options || {}
+      context.user = if options.respond_to?(:has_key?)
+                       context.user = options
+                     else
+                       logger.warn(
+                         "You're passing `options` - #{options.inspect}" \
+                         ' that are not a Hash. Your `options` will be replaced with' \
+                         ' an empty Hash to ensure that an event will be sent to Sentry.io'
+                       )
+                       {}
+                     end
     end
 
     # Bind tags context. Merges with existing context (if any).

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -347,6 +347,7 @@ describe Raven::Event do
   end
 
   describe '.initialize' do
+    # NOTE: This test is completely pointless.
     it 'should not touch the env object for an ignored environment' do
       Raven.configure do |config|
         config.current_environment = 'test'

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -219,6 +219,43 @@ describe Raven::Instance do
     end
   end
 
+  describe '.user_context' do
+    context 'with `options` that is a hash' do
+      let(:options) { { 'email' => 'foobar@example.com' } }
+
+      it(:aggregate_failures) do
+        expect(subject.logger).not_to receive(:warn)
+
+        subject.user_context(options)
+
+        expect(
+          subject.context.user
+        ).to eq(options)
+      end
+    end
+
+    context 'with `options` that is not a hash' do
+      let(:options) { ['email', 'foobar@example.com'] }
+
+      it(:aggregate_failures) do
+        expect(subject.logger).to receive(:warn)
+          .once
+          .with(
+            "You're passing `options` - #{options.inspect}" \
+            ' that are not a Hash. Your `options` will be replaced with' \
+            ' an empty Hash to ensure that an event will be sent to Sentry.io'
+          )
+          .and_call_original
+
+        subject.user_context(options)
+
+        expect(
+          subject.context.user
+        ).to eq({})
+      end
+    end
+  end
+
   describe '.last_event_id' do
     let(:message) { "Test message" }
 


### PR DESCRIPTION
When using Raven.user_context with `options` argument that's not a Hash,
the Raven::Event#initialize method will raise an Exception
and prevent an event being sent to Sentry at all.

Of course, this is not acceptable for an exception-sending service,
therefore log a warning that the Raven.user_context `options` argument
will be ignored to ensure that an event will be sent to Sentry.

@nateberkopec 

P.S The reason for this PR is cause I got bit hard by this bug and had 100+ major exception events ignored. :(