### PR TITLE
Allow disabling HTTP body truncation

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -221,6 +221,14 @@ Optional settings
           AdminMailer.email_admins("Oh god, it's on fire!").deliver_later
         }
 
+.. describe:: truncate_http_body
+
+    By default the HTTP body of a request is truncated to 2048 characters. It can be disabled.
+
+    .. code-block:: ruby
+
+        config.truncate_http_body = false
+
 Environment Variables
 ---------------------
 

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -146,6 +146,9 @@ module Raven
     # E.g. lambda { |event| Thread.new { MyJobProcessor.send_email(event) } }
     attr_reader :transport_failure_callback
 
+    # Enables HTTP body truncation when true (default).
+    attr_accessor :truncate_http_body
+
     # Errors object - an Array that contains error messages. See #
     attr_reader :errors
 
@@ -206,6 +209,7 @@ module Raven
       self.tags = {}
       self.timeout = 2
       self.transport_failure_callback = false
+      self.truncate_http_body = true
       self.sanitize_data_for_request_methods = DEFAULT_REQUEST_METHODS_FOR_DATA_SANITIZATION.dup
     end
 

--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -84,7 +84,9 @@ module Raven
       if request.form_data?
         request.POST
       elsif request.body # JSON requests, etc
-        data = request.body.read(2048) # Sentry server limit
+        length = 2048 if Raven.configuration.truncate_http_body
+
+        data = request.body.read(length)
         request.body.rewind
         data
       end

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -187,6 +187,20 @@ describe Raven::Event do
     it "truncates http data" do
       expect(hash[:request][:data]).to eq("a" * 2048)
     end
+
+    context "with truncation disabled" do
+      before(:each) do
+        Raven.configuration.truncate_http_body = false
+      end
+
+      after(:each) do
+        Raven.configuration.truncate_http_body = true
+      end
+
+      it "does not truncate http data" do
+        expect(hash[:request][:data]).to eq("a" * 16_000)
+      end
+    end
   end
 
   context 'configuration tags specified' do


### PR DESCRIPTION
We're using an On-Premise install and would like to prevent truncation of the raw body. I considered requiring truncation if the DSN points to `sentry.io` but decided to ask if that would be proper here first. Another consideration would be changing this from a boolean to an integer configuration of the max length.