### PR TITLE
Fix stack_trace error in ruby 2.4.1

### DIFF
--- a/lib/raven/interfaces/stack_trace.rb
+++ b/lib/raven/interfaces/stack_trace.rb
@@ -73,7 +73,7 @@ module Raven
       end
 
       def longest_load_path
-        $LOAD_PATH.select { |s| abs_path.start_with?(s) }.max_by(&:length)
+        $LOAD_PATH.select { |s| abs_path.start_with?(s.to_s) }.max_by(&:length)
       end
     end
   end


### PR DESCRIPTION
```/Users/david/.rvm/gems/ruby-2.4.1/bundler/gems/raven-ruby-cbf2d6033c3e/lib/raven/interfaces/stack_trace.rb:76:in `start_with?': no implicit conversion of Pathname into String (TypeError)```

Seems to be related to #113 