### PR TITLE
Fix typo which causes `SystemStackError: stack level too deep`

### DIFF
--- a/lib/raven/backtrace.rb
+++ b/lib/raven/backtrace.rb
@@ -110,7 +110,7 @@ module Raven
     end
 
     def inspect
-      "<Backtrace: " + lines.map(&inspect).join(", ") + ">"
+      "<Backtrace: " + lines.map(&:inspect).join(", ") + ">"
     end
 
     def to_s


### PR DESCRIPTION
Couldn't find any tests, but here's a POC in IRB:

```
irb(main):001:0> require "raven"
=> true
irb(main):002:0> Raven::Backtrace.parse(caller)
SystemStackError: stack level too deep
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
        from /usr/local/bundle/gems/sentry-raven-2.4.0/lib/raven/backtrace.rb:113:in `inspect'
... 10873 levels...
        from /usr/local/bin/irb:11:in `<top (required)>'
        from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `load'
        from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `kernel_load'                                                                                                                   from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:27:in `run'                                                                                                                           from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli.rb:335:in `exec'                                                                                                                              from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'                                                                                                       from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'                                                                                        from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'                                                                                                         from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli.rb:20:in `dispatch'                                                                                                                           from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'                                                                                                       from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli.rb:11:in `start'                                                                                                                              from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/exe/bundle:32:in `block in <top (required)>'                                                                                                                  from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'                                                                                                  from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/exe/bundle:24:in `<top (required)>'
        from /usr/local/bin/bundle:23:in `load'
        from /usr/local/bin/bundle:23:in `<main>'
```

And then fixed by patching `Raven::Backtrace#inspect`:

```
irb(main):003:0> class Raven::Backtrace
irb(main):004:1>   def inspect
irb(main):005:2>     "<Backtrace: " + lines.map(&:inspect).join(", ") + ">"
irb(main):006:2>   end
irb(main):007:1> end
=> :inspect
irb(main):008:0> Raven::Backtrace.parse(caller)
=> <Backtrace: <Line:/usr/local/lib/ruby/2.4.0/irb/workspace.rb:87:in `eval'>, <Line:/usr/local/lib/ruby/2.4.0/irb/workspace.rb:87:in `evaluate'>, <Line:/usr/local/lib/ruby/2.4.0/irb/context.rb:381:in `evaluate'>, <Line:/usr/local/lib/ruby/2.4.0/irb.rb:493:in `block (2 levels) in eval_input'>, <Line:/usr/local/lib/ruby/2.4.0/irb.rb:627:in `signal_status'>, <Line:/usr/local/lib/ruby/2.4.0/irb.rb:490:in `block in eval_input'>,
 <Line:/usr/local/lib/ruby/2.4.0/irb/ruby-lex.rb:246:in `block (2 levels) in each_top_level_statement'>, <Line:/usr/local/lib/ruby/2.4.0/irb/ruby-lex.rb:232:in `loop'>, <Line:/usr/local/lib/ruby/2.4.0/irb/ruby-lex.rb:232:in `block in each_top_level_statement'>, <Line:/usr/local/lib/ruby/2.4.0/irb/ruby-lex.rb:231:in `catch'>, <Line:/usr/local/lib/ruby/2.4.0/irb/ruby-lex.rb:231:in `each_top_level_statement'>, <Line:/usr/local/
lib/ruby/2.4.0/irb.rb:489:in `eval_input'>, <Line:/usr/local/lib/ruby/2.4.0/irb.rb:430:in `block in run'>, <Line:/usr/local/lib/ruby/2.4.0/irb.rb:429:in `catch'>, <Line:/usr/local/lib/ruby/2.4.0/irb.rb:429:in `run'>, <Line:/usr/local/lib/ruby/2.4.0/irb.rb:385:in `start'>, <Line:/usr/local/bin/irb:11:in `<top (required)>'>, <Line:/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `load'>, <Line:/
usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:74:in `kernel_load'>, <Line:/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli/exec.rb:27:in `run'>, <Line:/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli.rb:335:in `exec'>, <Line:/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'>, <Line:/usr/local/lib/ruby/gems
/2.4.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'>, <Line:/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'>, <Line:/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli.rb:20:in `dispatch'>, <Line:/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'>, <Line:/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/cli.rb:11:in `start'>, <Line:/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/exe/bundle:32:in `block in <top (required)>'>, <Line:/usr/local/lib/ru
by/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'>, <Line:/usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/exe/bundle:24:in `<top (required)>'>, <Line:/usr/local/bin/bundle:23:in `load'>, <Line:/usr/local/bin/bundle:23:in `<main>'>>
```