### PR TITLE
Add `user` to the available additional context attributes list

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -24,6 +24,7 @@ The following attributes are available:
 * ``server_name``: the hostname of the server
 * ``tags``: a mapping of tags describing this event
 * ``extra``: a mapping of arbitrary context
+* ``user``: a mapping of user context
 
 Providing Request Context
 -------------------------


### PR DESCRIPTION
Hi, I found that `Raven.capture_exception` receives `user` context option.
But it is not listed at [document](https://docs.sentry.io/clients/ruby/context/), so I made a patch.

```ruby
Raven.capture_exception(e, user: { id: 123 }) # it works just like Raven. user_context(id: 123)
```

Ref: https://github.com/getsentry/raven-ruby/blob/master/lib/raven/event.rb#L46