### PR TITLE
Defer to rescuable/rescue_from inside of ActiveJob

### DIFF
--- a/lib/raven/integrations/rails/active_job.rb
+++ b/lib/raven/integrations/rails/active_job.rb
@@ -17,6 +17,7 @@ module Raven
       def capture_and_reraise_with_sentry(job, block)
         block.call
       rescue Exception => exception # rubocop:disable Lint/RescueException
+        return if rescue_with_handler(exception)
         return if already_supported_by_specific_integration?(job)
         Raven.capture_exception(exception, :extra => raven_context(job))
         raise exception

--- a/spec/raven/integrations/rails/activejob_spec.rb
+++ b/spec/raven/integrations/rails/activejob_spec.rb
@@ -14,8 +14,9 @@ if defined? ActiveJob
   end
 
   class RescuedActiveJob < MyActiveJob
-    rescue_from TestError do
-      # do nothing
+    rescue_from TestError, with: :rescue_callback
+
+    def rescue_callback(error)
     end
   end
 end
@@ -58,10 +59,12 @@ describe "ActiveJob integration", :rails => true do
   context 'using rescue_from' do
     it 'does not trigger Sentry' do
       job = RescuedActiveJob.new
+      allow(job).to receive(:rescue_callback)
 
       expect { job.perform_now }.not_to raise_error
 
       expect(Raven.client.transport.events.size).to eq(0)
+      expect(job).to have_received(:rescue_callback).once
     end
   end
 end

--- a/spec/raven/integrations/rails/activejob_spec.rb
+++ b/spec/raven/integrations/rails/activejob_spec.rb
@@ -14,7 +14,7 @@ if defined? ActiveJob
   end
 
   class RescuedActiveJob < MyActiveJob
-    rescue_from TestError, with: :rescue_callback
+    rescue_from TestError, :with => :rescue_callback
 
     def rescue_callback(error)
     end

--- a/spec/raven/integrations/rails/activejob_spec.rb
+++ b/spec/raven/integrations/rails/activejob_spec.rb
@@ -12,6 +12,12 @@ if defined? ActiveJob
       raise TestError, "Boom!"
     end
   end
+
+  class RescuedActiveJob < MyActiveJob
+    rescue_from TestError do
+      # do nothing
+    end
+  end
 end
 
 describe "ActiveJob integration", :rails => true do
@@ -47,5 +53,15 @@ describe "ActiveJob integration", :rails => true do
     event = JSON.parse!(Raven.client.transport.events.first[1])
 
     expect(event["extra"]["foo"]).to eq(nil)
+  end
+
+  context 'using rescue_from' do
+    it 'does not trigger Sentry' do
+      job = RescuedActiveJob.new
+
+      expect { job.perform_now }.not_to raise_error
+
+      expect(Raven.client.transport.events.size).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
This PR ensures that ActiveJob exceptions that are rescued using `rescue_from` are not sent to Sentry.