### PR TITLE
rescue errors occuring in #format_headers_for_sentry

### DIFF
--- a/spec/raven/integrations/rack_spec.rb
+++ b/spec/raven/integrations/rack_spec.rb
@@ -97,6 +97,19 @@ describe Raven::Rack do
     expect(interface.headers["Version"]).to eq("HTTP/2.0")
   end
 
+  it 'does not fail if an object in the env cannot be cast to string' do
+    obj = Class.new do
+      def to_s
+        raise 'Could not stringify object!'
+      end
+    end.new
+
+    env = { "HTTP_FOO" => "BAR", "rails_object" => obj }
+    interface = Raven::HttpInterface.new
+
+    expect { interface.from_rack(env) }.to_not raise_error
+  end
+
   it 'should pass rack/lint' do
     env = Rack::MockRequest.env_for("/test")
 


### PR DESCRIPTION
This is the cause of #720 and the reason we were not seeing this error in Sentry.

`ActionDispatch::RemoteIP` raises an exception when certain IP origination headers do not match. (https://github.com/rails/rails/blob/b70fc698e157f2a768ba42efac08c08f4786b01c/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134) Sentry was correctly capturing this error, but during `format_headers_for_sentry` was calling `to_s` on the `RemoteIP` object, which re-raised the error.

The exception can be reproduced by setting up the basic Rails app from #720 and running
```
curl -H "X_FORWARDED_FOR: 1.2.1.1" \
-H "CLIENT_IP: 2.2.2.2" \
"localhost:3000"
```