### PR TITLE
sanitize_fields accepts a Proc

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -97,7 +97,8 @@ module Raven
     # By default, Sentry censors Hash values when their keys match things like
     # "secret", "password", etc. Provide an array of Strings that, when matched in
     # a hash key, will be censored and not sent to Sentry.
-    attr_accessor :sanitize_fields
+    # Also takes a Proc, but .call on that Proc must return an array of Strings.
+    attr_reader :sanitize_fields
 
     # If you're sure you want to override the default sanitization values, you can
     # add to them to an array of Strings here, e.g. %w(authorization password)
@@ -302,6 +303,15 @@ module Raven
       else
         Dir.pwd
       end
+    end
+
+    def sanitize_fields=(ary_or_proc)
+      @sanitize_fields = if ary_or_proc.respond_to?(:call)
+                           ary_or_proc.call
+                         else
+                           ary_or_proc
+                         end
+      raise Error, "sanitize_fields must be an Array" unless @sanitize_fields.is_a?(Array)
     end
 
     private

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -100,4 +100,14 @@ describe Raven::Configuration do
       expect(subject.errors).to eq(["No public_key specified", "No secret_key specified", "No project_id specified"])
     end
   end
+
+  it "converts sanitize_fields Procs into arrays of strings" do
+    subject.sanitize_fields = proc { ["test"] }
+
+    expect(subject.sanitize_fields).to eq(["test"])
+  end
+
+  it "raises if sanitize_fields.call does not return an array" do
+    expect { subject.sanitize_fields = proc { "test" } }.to raise_error(Raven::Error)
+  end
 end


### PR DESCRIPTION
Close #307.

On second thought, I'm not even sure this would be useful. What's the benefit over just:

```ruby
config.sanitize_fields = MyProc.call
```

That way you'd at least get to provide arguments if you wanted. 

@GeekOnCoffee I know it's been literally years, but do you have any memory of this or any thoughts? 

If no one chimes in here I think I'll just drop this.