### PR TITLE
Allow `current_environment` to be set via an env variable

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -65,7 +65,7 @@ Optional settings
 
         config.environments = %w[ production ]
 
-    Sentry automatically sets the current environment to RAILS_ENV, or if it is not present, RACK_ENV. If you are using Sentry outside of Rack or Rails, or wish to override environment detection, you'll need to set the current environment yourself:
+    Sentry automatically sets the current environment to RAILS_ENV, or if it is not present, RACK_ENV. If you are using Sentry outside of Rack or Rails, or wish to override environment detection, you'll need to set the current environment by setting SENTRY_CURRENT_ENV or configuring the client yourself:
 
     .. code-block:: ruby
 

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -185,7 +185,7 @@ module Raven
     def initialize
       self.async = false
       self.context_lines = 3
-      self.current_environment = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'default'
+      self.current_environment = ENV['SENTRY_CURRENT_ENV'] || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'default'
       self.encoding = 'gzip'
       self.environments = []
       self.exclude_loggers = []

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -4,6 +4,7 @@ describe Raven::Configuration do
   before do
     # Make sure we reset the env in case something leaks in
     ENV.delete('SENTRY_DSN')
+    ENV.delete('SENTRY_CURRENT_ENV')
     ENV.delete('RAILS_ENV')
     ENV.delete('RACK_ENV')
   end
@@ -74,6 +75,36 @@ describe Raven::Configuration do
       subject.environments = %w(not_test)
       expect(subject.capture_allowed?).to eq(false)
       expect(subject.errors).to eq(["Not configured to send/capture in environment 'test'"])
+    end
+  end
+
+  context 'being initialized without a current environment' do
+    it 'defaults to "default"' do
+      expect(subject.current_environment).to eq('default')
+    end
+
+    it 'uses `SENTRY_CURRENT_ENV` env variable' do
+      ENV['SENTRY_CURRENT_ENV'] = 'set-with-sentry-current-env'
+      ENV['RAILS_ENV'] = 'set-with-rails-env'
+      ENV['RACK_ENV'] = 'set-with-rack-env'
+
+      expect(subject.current_environment).to eq('set-with-sentry-current-env')
+    end
+
+    it 'uses `RAILS_ENV` env variable' do
+      ENV['SENTRY_CURRENT_ENV'] = nil
+      ENV['RAILS_ENV'] = 'set-with-rails-env'
+      ENV['RACK_ENV'] = 'set-with-rack-env'
+
+      expect(subject.current_environment).to eq('set-with-rails-env')
+    end
+
+    it 'uses `RACK_ENV` env variable' do
+      ENV['SENTRY_CURRENT_ENV'] = nil
+      ENV['RAILS_ENV'] = nil
+      ENV['RACK_ENV'] = 'set-with-rack-env'
+
+      expect(subject.current_environment).to eq('set-with-rack-env')
     end
   end
 


### PR DESCRIPTION
This commit allows developers to set a `SENTRY_CURRENT_ENV` variable to configure the `current_environment` setting.

It serves as a fix for this scenario:

We run our production/staging/integration environments with Rails env "production". To differentiate errors from the environments we set `config.current_environment` with an environment variable:

https://github.com/alphagov/content-tagger/blob/bac2e1903aaf6ac12b3a103490517355673648dd/config/initializers/sentry.rb#L1-L3

However, this doesn't work in all situations. For example, when you run a rake task that doesn't exist, an error will be reported to Sentry. Because the initialiser that sets the `current_environment` hasn't run (yet) Sentry will use the `RAILS_ENV` to determine the current env. This causes all errors to be reported as "production" instead of production/staging/integration.
