### PR TITLE
Add Configuration to Silence Send Event Failure Logs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 262
+  Max: 263
   CountComments: false
 
 Metrics/AbcSize:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -212,6 +212,21 @@ Optional settings
 
         config.silence_ready = true
 
+.. describe:: silence_send_event_failure
+
+    When raven client fails to send the error event, Raven will write an error log to the log file, similar to following:
+
+    ``
+    ** E, [2017-08-14T23:05:41.239074 #4906] ERROR -- sentry: ** [Raven] Failed to submit event: Exception:
+    ** E, [2017-08-14T23:05:42.709556 #4318] ERROR -- sentry: ** [Raven] Unable to record event with remote Sentry server (Faraday::ClientError - the server responded with status 429)
+    ``
+
+    You can turn off this message:
+
+    .. code-block:: ruby
+
+        config.silence_send_event_failure = true
+
 .. describe:: ssl_verification
 
     By default SSL certificate verification is enabled in the client. It can be disabled.

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -39,7 +39,7 @@ module Raven
 
       begin
         transport.send_event(generate_auth_header, encoded_data,
-          :content_type => content_type)
+                             :content_type => content_type)
         successful_send
       rescue => e
         failed_send(e, event)

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -135,6 +135,9 @@ module Raven
     # Silences ready message when true.
     attr_accessor :silence_ready
 
+    # Silences send event failures when true.
+    attr_accessor :silence_send_event_failure
+
     # SSL settings passed directly to Faraday's ssl option
     attr_accessor :ssl
 

--- a/spec/raven/client_spec.rb
+++ b/spec/raven/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Raven::Client do
-  let(:callback) { double(call: nil) }
+  let(:callback) { double('call' => nil) }
   let(:configuration) do
     config                            = Raven::Configuration.new
     config.dsn                        = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
@@ -17,8 +17,8 @@ describe Raven::Client do
     end
 
     it 'should call transport_failure_callback if it is configured' do
-      expect(callback).to receive(:call).with({message: 'dummy event'})
-      client.send :failed_send, nil, {message: 'dummy event'}
+      expect(callback).to receive(:call).with('message' => 'dummy event')
+      client.send :failed_send, nil, 'message' => 'dummy event'
     end
 
     context 'when send event failures are silenced' do

--- a/spec/raven/client_spec.rb
+++ b/spec/raven/client_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Raven::Client do
+  let(:callback) { double(call: nil) }
+  let(:configuration) do
+    config                            = Raven::Configuration.new
+    config.dsn                        = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
+    config.logger                     = Logger.new(nil)
+    config.transport_failure_callback = callback
+    config
+  end
+  let(:client) { Raven::Client.new configuration }
+
+  describe '#failed_send' do
+    it 'should mark the client state as error' do
+      expect { client.send :failed_send, nil, nil }.to change { client.state.failed? }.from(false).to(true)
+    end
+
+    it 'should call transport_failure_callback if it is configured' do
+      expect(callback).to receive(:call).with({message: 'dummy event'})
+      client.send :failed_send, nil, {message: 'dummy event'}
+    end
+
+    context 'when send event failures are silenced' do
+      before { configuration.silence_send_event_failure = true }
+
+      it 'should not log anything to the logger' do
+        expect(configuration.logger).not_to receive(:error)
+        client.send :failed_send, nil, nil
+      end
+    end
+
+    context 'when send event failures are not silenced' do
+      it 'should log error to the logger' do
+        expect(configuration.logger).to receive(:error).exactly(2).times
+        client.send :failed_send, nil, nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently 80% of our logs are filled with these logs since we're hitting rate limits a lot.
our log size: `-rw-r--r-- 1 deploy nginx 102331944 Aug 15 00:10 production.log`

Obviously underlying problem is sending too many events and having a smaller plan than required but thought this should still be a config to reduce the log sizes in case bumping up the plan is not convenient for some people.

Since this is my first PR here, please let me know if I'm missing any conventions in this repo. Already ran tests, specs and rubocop. They are all green.