### PR TITLE
Add `after_send_event` post send hook

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 262
+  Max: 270
   CountComments: false
 
 Metrics/AbcSize:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -238,6 +238,16 @@ Optional settings
           AdminMailer.email_admins("Oh god, it's on fire!").deliver_later
         }
 
+.. describe:: after_send_event
+
+    After the event is sent to Sentry successfully, this Proc or lambda will be called.
+
+    .. code-block:: ruby
+
+        config.after_send_event = lambda { |event|
+          Redis.current.incr('errors_reported')
+        }
+
 Environment Variables
 ---------------------
 

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -36,7 +36,7 @@ module Raven
       begin
         transport.send_event(generate_auth_header, encoded_data,
                              :content_type => content_type)
-        successful_send
+        successful_send(event)
       rescue => e
         failed_send(e, event)
         return
@@ -87,8 +87,9 @@ module Raven
       'Sentry ' + fields.map { |key, value| "#{key}=#{value}" }.join(', ')
     end
 
-    def successful_send
+    def successful_send(event)
       @state.success
+      configuration.after_send_event.call(event) if configuration.after_send_event
     end
 
     def failed_send(e, event)

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -154,6 +154,10 @@ module Raven
     # E.g. lambda { |event| Thread.new { MyJobProcessor.send_email(event) } }
     attr_reader :transport_failure_callback
 
+    # Optional Proc, called when after an event is successfully sent to Sentry
+    # E.g. lambda { |event| Redis.current.incr('errors_reported') }
+    attr_reader :after_send_event
+
     # Errors object - an Array that contains error messages. See #
     attr_reader :errors
 
@@ -213,6 +217,7 @@ module Raven
       self.tags = {}
       self.timeout = 2
       self.transport_failure_callback = false
+      self.after_send_event = false
     end
 
     def server=(value)
@@ -255,6 +260,13 @@ module Raven
         raise(ArgumentError, "transport_failure_callback must be callable (or false to disable)")
       end
       @transport_failure_callback = value
+    end
+
+    def after_send_event=(value)
+      unless value == false || value.respond_to?(:call)
+        raise(ArgumentError, "after_send_event must be callable (or false to disable)")
+      end
+      @after_send_event = value
     end
 
     def should_capture=(value)

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -54,4 +54,14 @@ RSpec.describe "Integration tests" do
     @instance.capture_exception(build_exception)
     expect(@io.string).to match(/OK!$/)
   end
+
+  it "successfull sending should call after_send_event" do
+    @stubs.post('/prefix/sentry/api/42/store/') { [200, {}, 'ok'] }
+    @instance.configuration.server = 'http://12345:67890@sentry.localdomain/prefix/sentry/42'
+    @instance.configuration.after_send_event = proc { |_e| @io.puts "OK!" }
+
+    @instance.capture_exception(build_exception)
+
+    expect(@io.string).to match(/OK!$/)
+  end
 end


### PR DESCRIPTION
This adds a hook that is called after an event is successfully sent to Sentry.

It is mutually exclusive with `transport_failure_callback`. Together with that hook this fulfils the "Post-send hook" feature in the list of [expected features in clients][1]:

> Hook called on success or error, and passed the event and exception so that users can perform actions based on events actually being sent.

I've looked in the other client libraries for a good name for this and found 2 similar configs: `after_send_event` is used by the [elixir library][2], and `send_callback` is used by [PHP][3]. I liked `after_send_event` slightly better.

[1]: https://docs.sentry.io/clientdev/features/#post-send-hook
[2]: https://docs.sentry.io/clients/elixir/config/
[3]: https://docs.sentry.io/clients/php/config/

Closes https://github.com/getsentry/raven-ruby/issues/737.