### PR TITLE
Add `before_send_event` pre-send hook

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 262
+  Max: 270
   CountComments: false
 
 Metrics/AbcSize:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -228,6 +228,16 @@ Optional settings
 
         config.tags = { foo: :bar }
 
+.. describe:: before_send_event
+
+    Before an event is sent to Sentry, this Proc or lambda will be called.
+
+    .. code-block:: ruby
+
+        config.before_send_event = lambda { |event|
+          Redis.current.incr('errors_reported')
+        }
+
 .. describe:: transport_failure_callback
 
     If the transport fails to send an event to Sentry for any reason (either the Sentry server has returned a 4XX or 5XX response), this Proc or lambda will be called.

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -31,6 +31,8 @@ module Raven
 
       configuration.logger.info "Sending event #{event[:event_id]} to Sentry"
 
+      configuration.before_send_event.call(event) if configuration.before_send_event
+
       content_type, encoded_data = encode(event)
 
       begin

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -150,6 +150,10 @@ module Raven
     # Timeout when waiting for the server to return data in seconds.
     attr_accessor :timeout
 
+    # Optional Proc, called before the error is sent to Sentry
+    # E.g. lambda { |event| $statsd.incr('errors_reported') }
+    attr_reader :before_send_event
+
     # Optional Proc, called when the Sentry server cannot be contacted for any reason
     # E.g. lambda { |event| Thread.new { MyJobProcessor.send_email(event) } }
     attr_reader :transport_failure_callback
@@ -212,6 +216,7 @@ module Raven
       self.ssl_verification = true
       self.tags = {}
       self.timeout = 2
+      self.before_send_event = false
       self.transport_failure_callback = false
     end
 
@@ -248,6 +253,13 @@ module Raven
         raise(ArgumentError, "async must be callable (or false to disable)")
       end
       @async = value
+    end
+
+    def before_send_event=(value)
+      unless value == false || value.respond_to?(:call)
+        raise(ArgumentError, "before_send_event must be callable (or false to disable)")
+      end
+      @before_send_event = value
     end
 
     def transport_failure_callback=(value)

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -54,4 +54,12 @@ RSpec.describe "Integration tests" do
     @instance.capture_exception(build_exception)
     expect(@io.string).to match(/OK!$/)
   end
+
+  it "before sending calls the before send hook" do
+    @instance.configuration.before_send_event = proc { |_e| @io.puts "OK!" }
+
+    @instance.capture_exception(build_exception)
+
+    expect(@io.string).to match(/OK!$/)
+  end
 end


### PR DESCRIPTION
This adds a hook that will be called before an error will be reported.

Related to https://github.com/getsentry/raven-ruby/issues/737.

I'm not a 100% convinced that this is needed, since we already have a post hook for success (https://github.com/getsentry/raven-ruby/pull/750) and failure (`transport_failure_callback`) and we're able to determine whether to send the exception with `should_capture`. But for symmetry/discoverability it might be nice. It may also allow people to mutate events before sending (which is what the [elixir client][1] allows).

Thoughts @nateberkopec?

[1]: https://docs.sentry.io/clients/elixir/config/