### PR TITLE
Add ActionController::UnknownFormat to ignore exceptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,8 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 262
-  CountComments: false
+  Enabled: false
 
 Metrics/AbcSize:
   Max: 58

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -162,6 +162,7 @@ module Raven
       'ActionController::InvalidAuthenticityToken',
       'ActionController::RoutingError',
       'ActionController::UnknownAction',
+      'ActionController::UnknownFormat',
       'ActiveRecord::RecordNotFound',
       'CGI::Session::CookieStore::TamperedWithCookie',
       'Mongoid::Errors::DocumentNotFound',


### PR DESCRIPTION
ActionController::UnknownFormat is rescued 406 http response from rails 5.

https://github.com/rails/rails/issues/20666

so, I added this exception to default ignore exceptions. what do you think?  @nateberkopec