### PR TITLE
Travis: Use 2.2.8, 2.3.5, 2.4.2 in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ branches:
   only: [master]
 
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
 
 env:
   - RAILS_VERSION=4


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rbenv/ruby-build/tree/master/share/ruby-build