### PR TITLE
Exclude all 4xx Rails errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 262
+  Max: 300
   CountComments: false
 
 Metrics/AbcSize:

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -157,16 +157,30 @@ module Raven
     # Errors object - an Array that contains error messages. See #
     attr_reader :errors
 
+    # Most of these errors generate 4XX responses. In general, Sentry clients
+    # only automatically report 5xx responses.
     IGNORE_DEFAULT = [
       'AbstractController::ActionNotFound',
+      'ActionController::BadRequest',
       'ActionController::InvalidAuthenticityToken',
+      'ActionController::InvalidAuthenticityToken',
+      'ActionController::InvalidCrossOriginRequest',
+      'ActionController::MethodNotAllowed',
+      'ActionController::NotImplemented',
+      'ActionController::ParameterMissing',
       'ActionController::RoutingError',
       'ActionController::UnknownAction',
+      'ActionController::UnknownFormat',
+      'ActionController::UnknownHttpMethod',
+      'ActionDispatch::Http::Parameters::ParseError',
+      'ActionView::MissingTemplate',
+      'ActiveJob::DeserializationError', # Can cause infinite loops
       'ActiveRecord::RecordNotFound',
       'CGI::Session::CookieStore::TamperedWithCookie',
       'Mongoid::Errors::DocumentNotFound',
-      'Sinatra::NotFound',
-      'ActiveJob::DeserializationError'
+      'Rack::QueryParser::InvalidParameterError',
+      'Rack::QueryParser::ParameterTypeError',
+      'Sinatra::NotFound'
     ].freeze
 
     # Note the order - we have to remove circular references and bad characters


### PR DESCRIPTION
All Rails 4xx errors will be excluded with this change. I think this generally makes sense. Sentry's behavior, by default, should be to report programmer errors (bugs). A program rejecting invalid input (4xx) is not really an exception, and the program is behaving as intended.

+ Alphabetized the list
+ Added some comments