### PR TITLE
Fix LocalJumpError in Rails controllers

### DIFF
--- a/lib/raven/integrations/rails/controller_transaction.rb
+++ b/lib/raven/integrations/rails/controller_transaction.rb
@@ -2,12 +2,10 @@ module Raven
   class Rails
     module ControllerTransaction
       def self.included(base)
-        base.class_eval do
-          around_action do |controller|
-            Raven.context.transaction.push "#{controller.class}##{controller.action_name}"
-            yield
-            Raven.context.transaction.pop
-          end
+        base.around_action do |controller, block|
+          Raven.context.transaction.push "#{controller.class}##{controller.action_name}"
+          block.call
+          Raven.context.transaction.pop
         end
       end
     end

--- a/spec/raven/integrations/rails_spec.rb
+++ b/spec/raven/integrations/rails_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe "Rails Integration", :type => :request, :rails => true do
     expect(TestApp.middleware).to include(Raven::Rack)
   end
 
+  it "doesn't do anything on a normal route" do
+    get "/"
+
+    expect(response.status).to eq(200)
+    expect(Raven.client.transport.events.size).to eq(0)
+  end
+
   it "should capture exceptions in production" do
     get "/exception"
     expect(response.status).to eq(500)
@@ -25,6 +32,7 @@ RSpec.describe "Rails Integration", :type => :request, :rails => true do
     event = Raven.client.transport.events.first
     event = JSON.parse!(event[1])
 
+    expect(event["logentry"]["message"]).to eq("RuntimeError: An unhandled exception!")
     expect(event['request']['url']).to eq("http://www.example.com/exception")
   end
 

--- a/spec/support/test_rails_app/app.rb
+++ b/spec/support/test_rails_app/app.rb
@@ -35,6 +35,6 @@ class HelloController < ActionController::Base
   end
 
   def world
-    render :text => "Hello World!"
+    render :plain => "Hello World!"
   end
 end


### PR DESCRIPTION
There were a few messups here:

* The Rails controller tests never tested a "happy case" (that is, no exceptions)
* The Rails controller tests didn't check to see the exception they were actually catching - so the LocalJumpError went unnoticed!
* You can't `yield` from the block form of `around_action`
* I'm not sure why I thought class_eval was necessary here - it isn't.

Fix #773