### PR TITLE
Deep merge in #annotate_exception

### DIFF
--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -158,7 +158,7 @@ module Raven
     #   end
     def annotate_exception(exc, options = {})
       notes = (exc.instance_variable_defined?(:@__raven_context) && exc.instance_variable_get(:@__raven_context)) || {}
-      notes.merge!(options)
+      Raven::Utils::DeepMergeHash.deep_merge!(notes, options)
       exc.instance_variable_set(:@__raven_context, notes)
       exc
     end

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -175,6 +175,16 @@ RSpec.describe Raven::Instance do
       expect(exception.instance_variable_get(:@__raven_context)).to \
         be_kind_of Hash
     end
+
+    context 'when the exception already has context' do
+      it 'does a deep merge of options' do
+        subject.annotate_exception(exception, :extra => { :language => "ruby" })
+        subject.annotate_exception(exception, :extra => { :job_title => "engineer" })
+        expected_hash = { :extra => { :language => "ruby", :job_title => "engineer" } }
+        expect(exception.instance_variable_get(:@__raven_context)).to \
+          eq expected_hash
+      end
+    end
   end
 
   describe '#report_status' do

--- a/spec/raven/integrations/sidekiq_spec.rb
+++ b/spec/raven/integrations/sidekiq_spec.rb
@@ -33,6 +33,24 @@ if RUBY_VERSION > '2.0'
       Raven::SidekiqErrorHandler.new.call(exception, context)
     end
 
+    context "when the captured exception is already annotated" do
+      it "does a deep merge of options" do
+        exception = build_exception
+        Raven.annotate_exception(exception, :extra => { :job_title => "engineer" })
+        expected_options = {
+          :message => exception.message,
+          :extra => {
+            :sidekiq => context,
+            :job_title => "engineer"
+          }
+        }
+
+        expect(Raven::Event).to receive(:new).with(hash_including(expected_options))
+
+        Raven::SidekiqErrorHandler.new.call(exception, context)
+      end
+    end
+
     it "filters out ActiveJob keys" do
       exception = build_exception
       aj_context = context


### PR DESCRIPTION
#### Changes
1. I'd like to propose to perform a deep merge inside `annotate_exception` so no existing context is lost by accident.
2. Added a spec to make sure the Sidekiq error handler does perform a deep merge on the existing context.
