### PR TITLE
Suppress git errors and refactor Configuration class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 240
+  Max: 243
   CountComments: false
 
 Metrics/AbcSize:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 268
+  Max: 240
   CountComments: false
 
 Metrics/AbcSize:

--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -23,6 +23,7 @@ require 'raven/transports'
 require 'raven/transports/http'
 require 'raven/utils/deep_merge'
 require 'raven/utils/real_ip'
+require 'raven/utils/release'
 require 'raven/instance'
 
 require 'forwardable'

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -198,7 +198,7 @@ module Raven
       self.project_root = detect_project_root
       self.rails_activesupport_breadcrumbs = false
       self.rails_report_rescued_exceptions = true
-      self.release = Utils::Release.new(logger).detect_release
+      self.release = detect_release
       self.sample_rate = 1.0
       self.sanitize_credit_cards = true
       self.sanitize_fields = []
@@ -394,6 +394,10 @@ module Raven
 
     def running_on_heroku?
       File.directory?("/etc/heroku")
+    end
+
+    def detect_release
+      Utils::Release.new(logger).detect_release
     end
   end
 end

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -198,7 +198,7 @@ module Raven
       self.project_root = detect_project_root
       self.rails_activesupport_breadcrumbs = false
       self.rails_report_rescued_exceptions = true
-      self.release = Utils::Release.detect_release
+      self.release = Utils::Release.new(logger).detect_release
       self.sample_rate = 1.0
       self.sanitize_credit_cards = true
       self.sanitize_fields = []

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -375,7 +375,10 @@ module Raven
     end
 
     def detect_release_from_git
-      `git rev-parse --short HEAD`.strip if File.directory?(".git") rescue nil
+      release = `git rev-parse --short HEAD 2>/dev/null`.strip if File.directory?('.git')
+      return nil if release == ''
+    rescue
+      nil
     end
 
     def capture_in_current_environment?

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -377,7 +377,8 @@ module Raven
     def detect_release_from_git
       release = `git rev-parse --short HEAD 2>/dev/null`.strip if File.directory?('.git')
       return nil if release == ''
-    rescue
+      release
+    rescue StandardError
       nil
     end
 

--- a/lib/raven/utils/release.rb
+++ b/lib/raven/utils/release.rb
@@ -1,51 +1,55 @@
 module Raven
   module Utils
-    module Release
-      class << self
-        def detect_release
-          detect_release_from_git ||
-            detect_release_from_capistrano ||
-            detect_release_from_heroku
-        rescue StandardError => ex
-          logger.error "Error detecting release: #{ex.message}"
+    class Release
+      attr_accessor :logger
+
+      def initialize(logger)
+        self.logger = logger
+      end
+
+      def detect_release
+        detect_release_from_git ||
+          detect_release_from_capistrano ||
+          detect_release_from_heroku
+      rescue StandardError => ex
+        logger.error "Error detecting release: #{ex.message}"
+      end
+
+      private
+
+      def detect_release_from_git
+        release = `git rev-parse --short HEAD 2>/dev/null`.strip if File.directory?('.git')
+        return nil if release == ''
+        release
+      rescue StandardError
+        nil
+      end
+
+      def detect_release_from_capistrano
+        revision_file = File.join(project_root, 'REVISION')
+        revision_log = File.join(project_root, '..', 'revisions.log')
+
+        if File.exist?(revision_file)
+          File.read(revision_file).strip
+        elsif File.exist?(revision_log)
+          File.open(revision_log).to_a.last.strip.sub(/.*as release ([0-9]+).*/, '\1')
         end
+      end
 
-        private
+      def detect_release_from_heroku
+        return unless running_on_heroku?
+        logger.warn(heroku_dyno_metadata_message) && return unless ENV['HEROKU_SLUG_COMMIT']
 
-        def detect_release_from_git
-          release = `git rev-parse --short HEAD 2>/dev/null`.strip if File.directory?('.git')
-          return nil if release == ''
-          release
-        rescue StandardError
-          nil
-        end
+        ENV['HEROKU_SLUG_COMMIT']
+      end
 
-        def detect_release_from_capistrano
-          revision_file = File.join(project_root, 'REVISION')
-          revision_log = File.join(project_root, '..', 'revisions.log')
+      def running_on_heroku?
+        File.directory?("/etc/heroku")
+      end
 
-          if File.exist?(revision_file)
-            File.read(revision_file).strip
-          elsif File.exist?(revision_log)
-            File.open(revision_log).to_a.last.strip.sub(/.*as release ([0-9]+).*/, '\1')
-          end
-        end
-
-        def detect_release_from_heroku
-          return unless running_on_heroku?
-          logger.warn(heroku_dyno_metadata_message) && return unless ENV['HEROKU_SLUG_COMMIT']
-
-          ENV['HEROKU_SLUG_COMMIT']
-        end
-
-        def running_on_heroku?
-          File.directory?("/etc/heroku")
-        end
-
-        def heroku_dyno_metadata_message
-          "You are running on Heroku but haven't enabled Dyno Metadata. For Sentry's "\
-          "release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`"
-        end
+      def heroku_dyno_metadata_message
+        "You are running on Heroku but haven't enabled Dyno Metadata. For Sentry's "\
+        "release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`"
       end
     end
   end

--- a/lib/raven/utils/release.rb
+++ b/lib/raven/utils/release.rb
@@ -1,0 +1,52 @@
+module Raven
+  module Utils
+    module Release
+      class << self
+        def detect_release
+          detect_release_from_git ||
+            detect_release_from_capistrano ||
+            detect_release_from_heroku
+        rescue StandardError => ex
+          logger.error "Error detecting release: #{ex.message}"
+        end
+
+        private
+
+        def detect_release_from_git
+          release = `git rev-parse --short HEAD 2>/dev/null`.strip if File.directory?('.git')
+          return nil if release == ''
+          release
+        rescue StandardError
+          nil
+        end
+
+        def detect_release_from_capistrano
+          revision_file = File.join(project_root, 'REVISION')
+          revision_log = File.join(project_root, '..', 'revisions.log')
+
+          if File.exist?(revision_file)
+            File.read(revision_file).strip
+          elsif File.exist?(revision_log)
+            File.open(revision_log).to_a.last.strip.sub(/.*as release ([0-9]+).*/, '\1')
+          end
+        end
+
+        def detect_release_from_heroku
+          return unless running_on_heroku?
+          logger.warn(heroku_dyno_metadata_message) && return unless ENV['HEROKU_SLUG_COMMIT']
+
+          ENV['HEROKU_SLUG_COMMIT']
+        end
+
+        def running_on_heroku?
+          File.directory?("/etc/heroku")
+        end
+
+        def heroku_dyno_metadata_message
+          "You are running on Heroku but haven't enabled Dyno Metadata. For Sentry's "\
+          "release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sometimes `.git` directory exists, but `git` is not installed and raven gem logs `No such file or directory - git` on loading. This PR suppresses this error.

Also, it moves release detecting code from a `Configuration` class to `Util::Release`