### PR TITLE
Prevent duplicated events when AJ adapter has a specific integration.

### DIFF
--- a/lib/raven/integrations/rails/active_job.rb
+++ b/lib/raven/integrations/rails/active_job.rb
@@ -28,7 +28,11 @@ module Raven
       end
 
       def already_supported_by_specific_integration?(job)
-        ALREADY_SUPPORTED_SENTRY_ADAPTERS.include?(job.class.queue_adapter.to_s)
+        if ::Rails.version.to_f < 5.0
+          ALREADY_SUPPORTED_SENTRY_ADAPTERS.include?(job.class.queue_adapter.to_s)
+        else
+          ALREADY_SUPPORTED_SENTRY_ADAPTERS.include?(job.class.queue_adapter.class.to_s)
+        end
       end
 
       def raven_context(job)

--- a/spec/raven/integrations/rails/activejob_spec.rb
+++ b/spec/raven/integrations/rails/activejob_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 if defined? ActiveJob
   class MyActiveJob < ActiveJob::Base
-    self.queue_adapter = :inline
     self.logger = nil
 
     class TestError < RuntimeError
@@ -30,6 +29,7 @@ RSpec.describe "ActiveJob integration", :rails => true do
 
   before(:each) do
     Raven.client.transport.events = []
+    MyActiveJob.queue_adapter = :inline
   end
 
   it_should_behave_like "Raven default capture behavior" do
@@ -68,10 +68,8 @@ RSpec.describe "ActiveJob integration", :rails => true do
 
   context "when we are using an adapter which has a specific integration" do
     it "does not trigger sentry and re-raises" do
+      MyActiveJob.queue_adapter = :sidekiq
       job = MyActiveJob.new
-      def job.already_supported_by_specific_integration?(*)
-        true
-      end
 
       expect { job.perform_now }.to raise_error(MyActiveJob::TestError)
 


### PR DESCRIPTION
In rails 5, the job class’s `queue_adapter` property is not a class (such as `ActiveJob::QueueAdapters::SidekiqAdapter`) like it was in rails 4, but an instance (of a class such as `ActiveJob::QueueAdapters::SidekiqAdapter`).

The specs were previously not testing the logic in `already_supported_by_specific_integration?` which is why there wasn’t a failing spec.