### PR TITLE
Sentry calls rescue_from handler twice if exception occurs in rescue_from

### DIFF
--- a/lib/raven/integrations/rails/active_job.rb
+++ b/lib/raven/integrations/rails/active_job.rb
@@ -17,7 +17,10 @@ module Raven
       def capture_and_reraise_with_sentry(job, block)
         block.call
       rescue Exception => exception # rubocop:disable Lint/RescueException
-        return if rescue_with_handler(exception)
+        if handler_for_rescue(exception)
+          raise
+        end
+
         unless already_supported_by_specific_integration?(job)
           Raven.capture_exception(exception, :extra => raven_context(job))
         end

--- a/spec/raven/integrations/rails/activejob_spec.rb
+++ b/spec/raven/integrations/rails/activejob_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe "ActiveJob integration", :rails => true do
       expect(job).to have_received(:rescue_callback).once
       expect(Raven.client.transport.events.size).to eq(1)
     end
+
   end
 
   context "when we are using an adapter which has a specific integration" do


### PR DESCRIPTION
I've added a failing test case to show what I'm talking about. Basically, because the sentry gem relies on `rescue_with_handler` there is an edge case where a legitimate error that Sentry should log, but instead the error gets rescued and sent back to the rescue_from handler. 