### PR TITLE
Add option to disable logging of IP addresses

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -46,6 +46,9 @@ module Raven
     # the disk. See Raven::LineCache for the required interface you must implement.
     attr_accessor :linecache
 
+    # Log user's IP address? Default: true.
+    attr_accessor :log_ip_address
+
     # Logger used by Raven. In Rails, this is the Rails logger, otherwise
     # Raven provides its own Raven::Logger.
     attr_accessor :logger
@@ -192,6 +195,7 @@ module Raven
       self.exclude_loggers = []
       self.excluded_exceptions = IGNORE_DEFAULT.dup
       self.linecache = ::Raven::LineCache.new
+      self.log_ip_address = true
       self.logger = ::Raven::Logger.new(STDOUT)
       self.open_timeout = 1
       self.processors = DEFAULT_PROCESSORS.dup

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -216,7 +216,9 @@ module Raven
       interface :http do |int|
         int.from_rack(context.rack_env)
       end
-      context.user[:ip_address] = calculate_real_ip_from_rack
+      if configuration[:log_ip_address]
+        context.user[:ip_address] = calculate_real_ip_from_rack
+      end
     end
 
     # When behind a proxy (or if the user is using a proxy), we can't use

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -175,6 +175,19 @@ RSpec.describe Raven::Event do
     end
   end
 
+  context "ip address logging is disabled" do
+    let(:hash) do
+      Raven.rack_context('HTTP_X_FORWARDED_FOR' => '1.1.1.1')
+      config = Raven::Configuration.new
+      config.log_ip_address = false
+      Raven::Event.new(configuration: config).to_hash
+    end
+
+    it "does not set ip address" do
+      expect(hash[:user][:ip_address]).to be_nil
+    end
+  end
+
   context "rack context, long body" do
     let(:hash) do
       Raven.rack_context('REQUEST_METHOD' => 'GET',


### PR DESCRIPTION
We are preparing our APP for [GDPR][1] and we do not want to send any personalized information to Sentry, but raven-ruby sends user's IP address to Sentry by default. This commit introduces an option to disable this functionality.

[1]: https://en.wikipedia.org/wiki/General_Data_Protection_Regulation