### PR TITLE
Fixes #823 context attributes with nil raises error

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -39,7 +39,7 @@ module Raven
 
       # Allow attributes to be set on the event at initialization
       yield self if block_given?
-      init.each_pair { |key, val| public_send("#{key}=", val) }
+      init.each_pair { |key, val| public_send("#{key}=", val) unless val.nil? }
 
       set_core_attributes_from_configuration
       set_core_attributes_from_context

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -72,6 +72,26 @@ RSpec.describe Raven::Event do
     end
   end
 
+  context 'parameter entries are nil' do
+    let(:hash) do
+      Raven::Event.new(:message => 'test',
+                       :level => 'warn',
+                       :logger => 'foo',
+                       :tags => nil,
+                       :extra => nil,
+                       :user => nil,
+                       :server_name => 'foo.local',
+                       :release => '721e41770371db95eee98ca2707686226b993eda',
+                       :environment => 'production').to_hash
+    end
+
+    it "skips nil values" do
+      expect(hash[:extra]).to eq(Raven.context.extra)
+      expect(hash[:user]).to eq(Raven.context.user)
+      expect(hash[:tags]).to eq(Raven.configuration.tags)
+    end
+  end
+
   context 'user context specified' do
     let(:hash) do
       Raven.user_context('id' => 'hello')


### PR DESCRIPTION
https://github.com/getsentry/raven-ruby/issues/823

* skipps context attributes with value nil