### PR TITLE
Travis: jruby-9.1.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ matrix:
       env: RAILS_VERSION=4
     - rvm: jruby-1.7.27
       env: JRUBY_OPTS="--dev" RAILS_VERSION=4
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.17.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M" RAILS_VERSION=4
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.17.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M" RAILS_VERSION=5
     - rvm: ruby-head
       env: RAILS_VERSION=0


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/04/23/jruby-9-1-17-0.html