### PR TITLE
adding stdout transport

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 268
+  Max: 270
   CountComments: false
 
 Metrics/AbcSize:

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -50,6 +50,8 @@ module Raven
         case configuration.scheme
         when 'http', 'https'
           Transports::HTTP.new(configuration)
+        when 'stdout'
+          Transports::Stdout.new(configuration)
         when 'dummy'
           Transports::Dummy.new(configuration)
         else

--- a/lib/raven/transports/stdout.rb
+++ b/lib/raven/transports/stdout.rb
@@ -1,0 +1,20 @@
+module Raven
+  module Transports
+    class Stdout < Transport
+      attr_accessor :events
+
+      def initialize(*)
+        super
+      end
+
+      def send_event(_auth_header, data, _options = {})
+        unless configuration.sending_allowed?
+          logger.debug("Event not sent: #{configuration.error_messages}")
+        end
+
+        $stdout.puts data
+        $stdout.flush
+      end
+    end
+  end
+end

--- a/spec/raven/transports/stdout_spec.rb
+++ b/spec/raven/transports/stdout_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Raven::Transports::Stdout do
+  let(:config) { Raven::Configuration.new.tap { |c| c.dsn = 'stdout://12345:67890@sentry.localdomain/sentry/42' } }
+  let(:client) { Raven::Client.new(config) }
+
+  it 'should write to stdout' do
+    event = JSON.generate(Raven::Event.from_message("stdout test").to_hash)
+    expect { client.send(:transport).send_event("test", event) }.not_to raise_error
+  end
+end

--- a/spec/raven/transports/stdout_spec.rb
+++ b/spec/raven/transports/stdout_spec.rb
@@ -7,6 +7,5 @@ RSpec.describe Raven::Transports::Stdout do
   it 'should write to stdout' do
     event = JSON.generate(Raven::Event.from_message("this is an STDOUT transport test").to_hash)
     expect { client.send(:transport).send_event("stdout test", event) }.to output(/\"message\":\"this is an STDOUT transport test\"/).to_stdout
-
   end
 end

--- a/spec/raven/transports/stdout_spec.rb
+++ b/spec/raven/transports/stdout_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Raven::Transports::Stdout do
   let(:client) { Raven::Client.new(config) }
 
   it 'should write to stdout' do
-    event = JSON.generate(Raven::Event.from_message("stdout test").to_hash)
-    expect { client.send(:transport).send_event("test", event) }.not_to raise_error
+    event = JSON.generate(Raven::Event.from_message("this is an STDOUT transport test").to_hash)
+    expect { client.send(:transport).send_event("stdout test", event) }.to output(/\"message\":\"this is an STDOUT transport test\"/).to_stdout
+
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'sentry-raven-without-integrations'
 require 'raven/transports/dummy'
+require 'raven/transports/stdout'
 
 Raven.configure do |config|
   config.dsn = "dummy://12345:67890@sentry.localdomain/sentry/42"


### PR DESCRIPTION
Our developers see a value in using Sentry platform for application errors processing.
But we can't use HTTP/S transport to propagate application errors.
Our system runs on Kubernetes platform using Docker containers.
All components obey to `12factor` rules.
All logs are written to `stdout` stream, picked up by `fluentd` plugins and sent to the corresponding receivers.

