### PR TITLE
Suppress warning about enabling dyno metadata in Heroku CI

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -349,6 +349,7 @@ module Raven
 
     def detect_release_from_heroku
       return unless running_on_heroku?
+      return if ENV['CI']
       logger.warn(heroku_dyno_metadata_message) && return unless ENV['HEROKU_SLUG_COMMIT']
 
       ENV['HEROKU_SLUG_COMMIT']


### PR DESCRIPTION
Suppress following warning since we could not enable heroku labs feature in Heroku CI.
```
WARN -- sentry: ** [Raven] You are running on Heroku but haven't enabled Dyno Metadata. For Sentry's release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`
```

- https://stackoverflow.com/a/37571569
- https://devcenter.heroku.com/articles/heroku-ci#configuration-using-app-json