### PR TITLE
`Raven.capture(silent: true)` option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 268
+  Max: 270
   CountComments: false
 
 Metrics/AbcSize:

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -87,6 +87,10 @@ module Raven
     #   Raven.capture do
     #     MyApp.run
     #   end
+    #
+    #   Raven.capture(silent: true) do
+    #     raise "Boom"      # does not raises exception but sends it to Sentry server
+    #   end
     def capture(options = {})
       if block_given?
         begin
@@ -95,7 +99,7 @@ module Raven
           raise # Don't capture Raven errors
         rescue Exception => e
           capture_type(e, options)
-          raise
+          raise unless options[:silent]
         end
       else
         install_at_exit_hook(options)

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -153,6 +153,14 @@ RSpec.describe Raven::Instance do
       it 'yields to the given block' do
         expect { |b| subject.capture(&b) }.to yield_with_no_args
       end
+
+      it 'raises exception with no :silent option' do
+        expect { subject.capture{ raise RuntimeError } }.to raise_error RuntimeError
+      end
+
+      it 'not raises exception with :silent option' do
+        expect { subject.capture(silent: true) { raise RuntimeError } }.not_to raise_error RuntimeError
+      end
     end
 
     it 'does not install an at_exit hook' do

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -155,11 +155,11 @@ RSpec.describe Raven::Instance do
       end
 
       it 'raises exception with no :silent option' do
-        expect { subject.capture{ raise RuntimeError } }.to raise_error RuntimeError
+        expect { subject.capture { raise RuntimeError } }.to raise_error RuntimeError
       end
 
       it 'not raises exception with :silent option' do
-        expect { subject.capture(silent: true) { raise RuntimeError } }.not_to raise_error RuntimeError
+        expect { subject.capture(silent => true) { raise RuntimeError } }.not_to raise_error RuntimeError
       end
     end
 


### PR DESCRIPTION
Added `:silent` option to `Raven.capture` method
It is useful on network requests when further execution should not be interrupted 
```
Raven.capture(silent: true) do
  SomeNetworkRequest.call
end
```

It is a short version of
```
begin
  SomeNetworkRequest.call
rescue => exception
  Raven.capture_exception(exception)
end
```