### PR TITLE
This commit suppresses a warning

### DIFF
--- a/sentry-raven.gemspec
+++ b/sentry-raven.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |gem|
   gem.version = Raven::VERSION
   gem.platform = Gem::Platform::RUBY
   gem.required_ruby_version = '>= 1.9.0'
-  gem.has_rdoc = true
   gem.extra_rdoc_files = ["README.md", "LICENSE"]
   gem.files = `git ls-files | grep -Ev '^(spec|benchmarks|examples)'`.split("\n")
   gem.bindir = "exe"


### PR DESCRIPTION
```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from raven-ruby/sentry-raven.gemspec:15.
```