### PR TITLE
Update `Metrics/ClassLength` to match lines of `Raven::Configuration`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 268
+  Max: 269
   CountComments: false
 
 Metrics/AbcSize:


### PR DESCRIPTION
`Raven::Configuration` has too many lines after 34c0fbc19.
This commit update `Metrics/ClassLength` to fix RuboCop offenses.