### PR TITLE
Enable configurable rack environment recorded parameters. Fix #854.

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -193,6 +193,9 @@ module Raven
     # the dsn value, whether it's set via `config.dsn=` or `ENV["SENTRY_DSN"]`
     attr_reader :dsn
 
+    # Array of rack env parameters to be included in the event sent to sentry.
+    attr_accessor :rack_env_whitelist
+
     # Most of these errors generate 4XX responses. In general, Sentry clients
     # only automatically report 5xx responses.
     IGNORE_DEFAULT = [
@@ -232,6 +235,12 @@ module Raven
     HEROKU_DYNO_METADATA_MESSAGE = "You are running on Heroku but haven't enabled Dyno Metadata. For Sentry's "\
     "release detection to work correctly, please run `heroku labs:enable runtime-dyno-metadata`".freeze
 
+    RACK_ENV_WHITELIST_DEFAULT = %w(
+      REMOTE_ADDR
+      SERVER_NAME
+      SERVER_PORT
+    ).freeze
+
     LOG_PREFIX = "** [Raven] ".freeze
     MODULE_SEPARATOR = "::".freeze
 
@@ -270,6 +279,7 @@ module Raven
       self.timeout = 2
       self.transport_failure_callback = false
       self.before_send = false
+      self.rack_env_whitelist = RACK_ENV_WHITELIST_DEFAULT
     end
 
     def server=(value)

--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -128,8 +128,10 @@ module Raven
     end
 
     def format_env_for_sentry(env_hash)
+      return env_hash if Raven.configuration.rack_env_whitelist.empty?
+
       env_hash.select do |k, _v|
-        %w(REMOTE_ADDR SERVER_NAME SERVER_PORT).include? k.to_s
+        Raven.configuration.rack_env_whitelist.include? k.to_s
       end
     end
   end

--- a/spec/raven/integrations/rack_spec.rb
+++ b/spec/raven/integrations/rack_spec.rb
@@ -78,6 +78,33 @@ RSpec.describe Raven::Rack do
     stack.call({})
   end
 
+  it 'excludes non whitelisted params from rack env' do
+    interface = Raven::HttpInterface.new
+    additional_env = { "random_param" => "text", "query_string" => "test" }
+    new_env = env.merge(additional_env)
+    interface.from_rack(new_env)
+
+    expect(interface.env).to_not include(additional_env)
+  end
+
+  it 'formats rack env according to the provided whitelist' do
+    Raven.configuration.rack_env_whitelist = %w(random_param query_string)
+    interface = Raven::HttpInterface.new
+    additional_env = { "random_param" => "text", "query_string" => "test" }
+    new_env = env.merge(additional_env)
+    interface.from_rack(new_env)
+
+    expect(interface.env).to eq(additional_env)
+  end
+
+  it 'keeps the original env intact when an empty whitelist is provided' do
+    Raven.configuration.rack_env_whitelist = []
+    interface = Raven::HttpInterface.new
+    interface.from_rack(env)
+
+    expect(interface.env).to eq(env)
+  end
+
   it 'transforms headers to conform with the interface' do
     interface = Raven::HttpInterface.new
     new_env = env.merge("HTTP_VERSION" => "HTTP/1.1", "HTTP_COOKIE" => "test")


### PR DESCRIPTION
This commit adds a configuration option allowing rack env parameters
that are sent to sentry in an event to be configured by the user.

The default parameters remain the as they were so no breaking changes
are introduced.