### PR TITLE
Note that should_capture does not replace excluded_exceptions

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -203,6 +203,8 @@ Optional settings
 
         config.should_capture = Proc.new { |e| true unless e.contains_sensitive_info? }
 
+    This option does not replace or modify ``excluded_exceptions``.
+
 .. describe:: silence_ready
 
     Upon start, Raven will write the following message to the log at the INFO level:


### PR DESCRIPTION
I run into issues with other libraries where using two exception filters disables another filter which you have enabled. Noting this in the docs would be helpful.