### PR TITLE
Add configuration option to inspect nested exceptions for exclusion

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -23,6 +23,7 @@ require 'raven/transports'
 require 'raven/transports/http'
 require 'raven/utils/deep_merge'
 require 'raven/utils/real_ip'
+require 'raven/utils/exception_cause_chain'
 require 'raven/instance'
 
 require 'forwardable'

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -1,7 +1,7 @@
 require 'uri'
 
 module Raven
-  class Configuration
+  class Configuration # rubocop:disable Metrics/ClassLength
     # Directories to be recognized as part of your app. e.g. if you
     # have an `engines` dir at the root of your project, you may want
     # to set this to something like /(app|config|engines|lib)/
@@ -30,6 +30,10 @@ module Raven
     # Array of exception classes that should never be sent. See IGNORE_DEFAULT.
     # You should probably append to this rather than overwrite it.
     attr_accessor :excluded_exceptions
+
+    # Boolean to check nested exceptions when deciding if to exclude. Defaults to false
+    attr_accessor :inspect_exception_causes_for_exclusion
+    alias inspect_exception_causes_for_exclusion? inspect_exception_causes_for_exclusion
 
     # DSN component - set automatically if DSN provided
     attr_accessor :host
@@ -196,6 +200,7 @@ module Raven
       self.environments = []
       self.exclude_loggers = []
       self.excluded_exceptions = IGNORE_DEFAULT.dup
+      self.inspect_exception_causes_for_exclusion = false
       self.linecache = ::Raven::LineCache.new
       self.logger = ::Raven::Logger.new(STDOUT)
       self.open_timeout = 1
@@ -332,12 +337,22 @@ module Raven
       logger.error "Error detecting release: #{ex.message}"
     end
 
-    def excluded_exception?(exc)
-      excluded_exceptions.any? { |x| get_exception_class(x) === exc }
+    def excluded_exception?(incoming_exception)
+      excluded_exceptions.any? do |excluded_exception|
+        matches_exception?(get_exception_class(excluded_exception), incoming_exception)
+      end
     end
 
     def get_exception_class(x)
       x.is_a?(Module) ? x : qualified_const_get(x)
+    end
+
+    def matches_exception?(excluded_exception_class, incoming_exception)
+      if inspect_exception_causes_for_exclusion?
+        Raven::Utils::ExceptionCauseChain.exception_to_array(incoming_exception).any? { |cause| excluded_exception_class === cause }
+      else
+        excluded_exception_class === incoming_exception
+      end
     end
 
     # In Ruby <2.0 const_get can't lookup "SomeModule::SomeClass" in one go

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -139,7 +139,7 @@ module Raven
 
     def add_exception_interface(exc)
       interface(:exception) do |exc_int|
-        exceptions = exception_chain_to_array(exc)
+        exceptions = Raven::Utils::ExceptionCauseChain.exception_to_array(exc).reverse
         backtraces = Set.new
         exc_int.values = exceptions.map do |e|
           SingleExceptionInterface.new do |int|
@@ -235,20 +235,6 @@ module Raven
         Raven::Processor::RemoveCircularReferences,
         Raven::Processor::UTF8Conversion
       ].map { |v| v.new(self) }
-    end
-
-    def exception_chain_to_array(exc)
-      if exc.respond_to?(:cause) && exc.cause
-        exceptions = [exc]
-        while exc.cause
-          exc = exc.cause
-          break if exceptions.any? { |e| e.object_id == exc.object_id }
-          exceptions << exc
-        end
-        exceptions.reverse!
-      else
-        [exc]
-      end
     end
 
     def list_gem_specs

--- a/lib/raven/utils/exception_cause_chain.rb
+++ b/lib/raven/utils/exception_cause_chain.rb
@@ -1,0 +1,19 @@
+module Raven
+  module Utils
+    module ExceptionCauseChain
+      def self.exception_to_array(exception)
+        if exception.respond_to?(:cause) && exception.cause
+          exceptions = [exception]
+          while exception.cause
+            exception = exception.cause
+            break if exceptions.any? { |e| e.object_id == exception.object_id }
+            exceptions << exception
+          end
+          exceptions
+        else
+          [exception]
+        end
+      end
+    end
+  end
+end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -210,13 +210,24 @@ RSpec.describe Raven::Configuration do
           end
         end
 
+        # Only check causes when they're supported by the ruby version
         context 'when inspect_exception_causes_for_exclusion is true' do
           before do
             subject.inspect_exception_causes_for_exclusion = true
           end
 
-          it 'returns false' do
-            expect(subject.exception_class_allowed?(incoming_exception)).to eq false
+          if Exception.new.respond_to? :cause
+            context 'when the language version supports exception causes' do
+              it 'returns false' do
+                expect(subject.exception_class_allowed?(incoming_exception)).to eq false
+              end
+            end
+          else
+            context 'when the language version does not support exception causes' do
+              it 'returns true' do
+                expect(subject.exception_class_allowed?(incoming_exception)).to eq true
+              end
+            end
           end
         end
       end

--- a/spec/raven/utils/exception_cause_chain_spec.rb
+++ b/spec/raven/utils/exception_cause_chain_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Raven::Utils::ExceptionCauseChain do
+  describe '.exception_to_array' do
+    context 'when the exception has a cause' do
+      let(:exception) { build_exception_with_cause }
+
+      it 'captures the cause' do
+        expect(described_class.exception_to_array(exception).length).to eq(2)
+      end
+    end
+
+    context 'when the exception has nested causes' do
+      let(:exception) { build_exception_with_two_causes }
+
+      it 'captures nested causes' do
+        expect(described_class.exception_to_array(exception).length).to eq(3)
+      end
+    end
+
+    context 'when the exception has a recursive cause' do
+      let(:exception) { build_exception_with_recursive_cause }
+
+      it 'should handle it gracefully' do
+        expect(described_class.exception_to_array(exception).length).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/raven/utils/exception_cause_chain_spec.rb
+++ b/spec/raven/utils/exception_cause_chain_spec.rb
@@ -2,27 +2,40 @@ require 'spec_helper'
 
 RSpec.describe Raven::Utils::ExceptionCauseChain do
   describe '.exception_to_array' do
-    context 'when the exception has a cause' do
-      let(:exception) { build_exception_with_cause }
+    # Only check causes when they're supported
+    if Exception.new.respond_to? :cause
+      context 'when the ruby version supports exception causes' do
+        context 'when the exception has a cause' do
+          let(:exception) { build_exception_with_cause }
 
-      it 'captures the cause' do
-        expect(described_class.exception_to_array(exception).length).to eq(2)
+          it 'captures the cause' do
+            expect(described_class.exception_to_array(exception).length).to eq(2)
+          end
+        end
+
+        context 'when the exception has nested causes' do
+          let(:exception) { build_exception_with_two_causes }
+
+          it 'captures nested causes' do
+            expect(described_class.exception_to_array(exception).length).to eq(3)
+          end
+        end
+
+        context 'when the exception has a recursive cause' do
+          let(:exception) { build_exception_with_recursive_cause }
+
+          it 'should handle it gracefully' do
+            expect(described_class.exception_to_array(exception).length).to eq(1)
+          end
+        end
       end
-    end
+    else
+      context 'when the ruby version does not support exception causes' do
+        let(:exception) { build_exception_with_two_causes }
 
-    context 'when the exception has nested causes' do
-      let(:exception) { build_exception_with_two_causes }
-
-      it 'captures nested causes' do
-        expect(described_class.exception_to_array(exception).length).to eq(3)
-      end
-    end
-
-    context 'when the exception has a recursive cause' do
-      let(:exception) { build_exception_with_recursive_cause }
-
-      it 'should handle it gracefully' do
-        expect(described_class.exception_to_array(exception).length).to eq(1)
+        it 'returns the passed in exception' do
+          expect(described_class.exception_to_array(exception)).to eq [exception]
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,9 +42,9 @@ rescue ZeroDivisionError => exception
   return exception
 end
 
-def build_exception_with_cause
+def build_exception_with_cause(cause = "exception a")
   begin
-    raise "exception a"
+    raise cause
   rescue
     raise "exception b"
   end


### PR DESCRIPTION
Addresses https://github.com/getsentry/raven-ruby/issues/765, while not changing the behavior of existing configurations.

This adds a configuration option to inspect an incoming exception's causes when determining whether or not that exception should be excluded (which defaults to `false`), and implements the ability to exclude an exception based on its causes.