### PR TITLE
Add benchmark definition for benchmark_driver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "pry"
 gem "pry-coolline"
 gem "benchmark-ips"
 gem "benchmark-ipsa" if RUBY_VERSION > '2.0'
+gem "benchmark_driver"
 gem "ruby-prof", platform: :mri
 gem "rake"
 gem "rubocop", "~> 0.41.1" # Last version that supported 1.9, upgrade to 0.50 after we drop 1.9

--- a/benchmarks/benchmark.yml
+++ b/benchmarks/benchmark.yml
@@ -1,0 +1,43 @@
+# Usage:
+#   benchmark-driver benchmarks/benchmark.yml
+prelude: |
+  require 'bundler/setup'
+  require 'raven'
+  require 'raven/breadcrumbs/logger'
+  require 'raven/transports/dummy'
+  require 'rack/test'
+  require "./spec/support/test_rails_app/app"
+
+  def build_exception
+    1 / 0
+  rescue ZeroDivisionError => exception
+    exception
+  end
+
+  TestApp.configure do |config|
+    config.middleware.delete ActionDispatch::DebugExceptions
+    config.middleware.delete ActionDispatch::ShowExceptions
+  end
+
+  Raven.configure do |config|
+    config.logger = Logger.new(nil)
+    config.dsn = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
+  end
+
+  TestApp.initialize!
+  @app = Rack::MockRequest.new(TestApp)
+  RAILS_EXC = begin
+    @app.get("/exception")
+  rescue => exc
+    exc
+  end
+
+  DIVIDE_BY_ZERO = build_exception
+
+benchmark:
+  - name: simple
+    script: Raven.capture_exception(DIVIDE_BY_ZERO)
+    loop_count: 250
+  - name: rails
+    script: Raven.capture_exception(RAILS_EXC)
+    loop_count: 100


### PR DESCRIPTION
Having benchmark definition for [benchmark_driver.gem](https://github.com/benchmark-driver/benchmark-driver) in addition to benchmark-ips's one might be interesting since it allows to compare multiple Ruby implementations or options.

```
$ benchmark-driver --rbenv '2.6.0-preview3;2.6.0-preview3+JIT::2.6.0-preview3 --jit;jruby-9.2.0.0;jruby-9.2.0.0+indy::jruby-9.2.0.0 -Xcompile.invokedynamic=true' -v benchmarks/benchmark.yml
2.6.0-preview3: ruby 2.6.0preview3 (2018-11-06 trunk 65578) [x86_64-darwin17]
2.6.0-preview3+JIT: ruby 2.6.0preview3 (2018-11-06 trunk 65578) +JIT [x86_64-darwin17]
jruby-9.2.0.0: jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 Java HotSpot(TM) 64-Bit Server VM 25.131-b11 on 1.8.0_131-b11 +jit [darwin-x86_64]
jruby-9.2.0.0+indy: jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 Java HotSpot(TM) 64-Bit Server VM 25.131-b11 on 1.8.0_131-b11 +indy +jit [darwin-x86_64]
Calculating -------------------------------------
                     2.6.0-preview3  2.6.0-preview3+JIT  jruby-9.2.0.0  jruby-9.2.0.0+indy
              simple        309.898             250.507         82.827              65.353 i/s -     250.000 times in 0.806716s 0.997978s 3.018343s 3.825367s
               rails        111.665              94.181         36.060              25.724 i/s -     100.000 times in 0.895535s 1.061789s 2.773175s 3.887362s

Comparison:
                           simple
      2.6.0-preview3:       309.9 i/s
  2.6.0-preview3+JIT:       250.5 i/s - 1.24x  slower
       jruby-9.2.0.0:        82.8 i/s - 3.74x  slower
  jruby-9.2.0.0+indy:        65.4 i/s - 4.74x  slower

                            rails
      2.6.0-preview3:       111.7 i/s
  2.6.0-preview3+JIT:        94.2 i/s - 1.19x  slower
       jruby-9.2.0.0:        36.1 i/s - 3.10x  slower
  jruby-9.2.0.0+indy:        25.7 i/s - 4.34x  slower
```

(I wanted to include truffleruby here but I failed to install nokogiri since I don't have LLVM on this machine)

### several notes about the definition
* Actual script is created as `/tmp/xxx.rb`, so `require_relative` doesn't work for now
  * For this kind of reason, I intentionally avoided sharing code with benchmark-ips's one.
* A generated script is executed under `Bundler.with_clean_env`, so it has `require 'bundler/setup'` in prelude
* `loop_count` is just added for reducing the execution time by skipping warmup. On my machine, warmup generates that loop.
  * benchmark-driver's warmup doesn't warmup the measured execution anyway, since it's executed separately unlike benchmark-ips