### PR TITLE
Fix crash when the fork fails

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -99,7 +99,7 @@ module Raven
 
     def sys_command(command)
       result = `#{command} 2>&1` rescue nil
-      return if result.nil? || result.empty? || $CHILD_STATUS.exitstatus != 0
+      return if result.nil? || result.empty? || !$CHILD_STATUS || $CHILD_STATUS.exitstatus != 0
       result.strip
     end
   end


### PR DESCRIPTION
If the fork itself fails (not the process you exec later)
$CHILD_STATUS is not set and this throws an exceptions.  We saw this
when trying to send log messages to sentry while a server was out of
memory.