### PR TITLE
feat: Add before_send config option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
      - 'vendor/**/*'
 
 Metrics/ClassLength:
-  Max: 270
+  Max: 300
   CountComments: false
 
 Metrics/AbcSize:

--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,12 @@ gemspec
 
 if ENV["RAILS_VERSION"] && (ENV["RAILS_VERSION"].to_i == 4)
   gem "rails", "< 5"
-  gem "rspec-rails"
+  gem "rspec-rails", "> 3"
 elsif ENV["RAILS_VERSION"] && (ENV["RAILS_VERSION"].to_i == 0)
   # no-op. No Rails.
 else
   gem "rails", "< 6"
-  gem "rspec-rails"
+  gem "rspec-rails", "> 3"
 end
 
 if RUBY_VERSION < '2.0'
@@ -28,9 +28,9 @@ gem "pry-coolline"
 gem "benchmark-ips"
 gem "benchmark-ipsa" if RUBY_VERSION > '2.0'
 gem "ruby-prof", platform: :mri
-gem "rake"
+gem "rake", "> 12"
 gem "rubocop", "~> 0.41.1" # Last version that supported 1.9, upgrade to 0.50 after we drop 1.9
-gem "rspec"
+gem "rspec", "> 3"
 gem "capybara" # rspec system tests
 gem "puma" # rspec system tests
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 2.8.0
 -----
 
-* FEATURE: Added `config.before_send`. Provide a lambda or proc to this config setting, which will be `call`ed when before sending an event to Sentry. Receives `event` and `hint` as parameter. `hint` either contains the exception or the message. [@hazat, #847]
+* FEATURE: Added `config.before_send`. Provide a lambda or proc to this config setting, which will be `call`ed when before sending an event to Sentry. Receives `event` and `hint` as parameter. `hint` is a has {:exception => ex | nil, :message => message | nil}. [@hazat, #847]
 
 2.7.4
 -----

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+2.8.0
+-----
+
+* FEATURE: Added `config.before_send`. Provide a lambda or proc to this config setting, which will be `call`ed when before sending an event to Sentry. Receives `event` and `hint` as parameter. `hint` either contains the exception or the message. [@hazat, #847]
+
 2.7.4
 -----
 

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -21,6 +21,12 @@ module Raven
     def send_event(event, hint = nil)
       return false unless configuration.sending_allowed?(event)
 
+      event = configuration.before_send.call(event, hint) if configuration.before_send
+      if event.nil?
+        configuration.logger.info "Discarded event because before_send returned nil"
+        return
+      end
+
       # Convert to hash
       event = event.to_hash
 
@@ -32,9 +38,6 @@ module Raven
       configuration.logger.info "Sending event #{event[:event_id]} to Sentry"
 
       content_type, encoded_data = encode(event)
-
-      event = configuration.before_send.call(event, hint) if configuration.before_send
-      return false if event.nil?
 
       begin
         transport.send_event(generate_auth_header, encoded_data,

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -18,7 +18,7 @@ module Raven
       @state = ClientState.new
     end
 
-    def send_event(event)
+    def send_event(event, hint = nil)
       return false unless configuration.sending_allowed?(event)
 
       # Convert to hash
@@ -32,6 +32,9 @@ module Raven
       configuration.logger.info "Sending event #{event[:event_id]} to Sentry"
 
       content_type, encoded_data = encode(event)
+
+      event = configuration.before_send.call(event, hint) if configuration.before_send
+      return false unless !event.nil?
 
       begin
         transport.send_event(generate_auth_header, encoded_data,

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -34,7 +34,7 @@ module Raven
       content_type, encoded_data = encode(event)
 
       event = configuration.before_send.call(event, hint) if configuration.before_send
-      return false unless !event.nil?
+      return false if event.nil?
 
       begin
         transport.send_event(generate_auth_header, encoded_data,

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -156,6 +156,15 @@ module Raven
     # E.g. lambda { |event| Thread.new { MyJobProcessor.send_email(event) } }
     attr_reader :transport_failure_callback
 
+    # Optional Proc, called before sending an event to the server/
+    # E.g.: lambda { |event, hint| event }
+    # E.g.: lambda { |event, hint| nil }
+    # E.g.: lambda { |event, hint|
+    #   event[:message] = 'a'
+    #   event
+    # }
+    attr_reader :before_send
+
     # Errors object - an Array that contains error messages. See #
     attr_reader :errors
 
@@ -217,6 +226,7 @@ module Raven
       self.tags = {}
       self.timeout = 2
       self.transport_failure_callback = false
+      self.before_send = false
     end
 
     def server=(value)
@@ -267,6 +277,13 @@ module Raven
         raise ArgumentError, "should_capture must be callable (or false to disable)"
       end
       @should_capture = value
+    end
+
+    def before_send=(value)
+      unless value == false || value.respond_to?(:call)
+        raise ArgumentError, "before_send must be callable (or false to disable)"
+      end
+      @before_send = value
     end
 
     # Allows config options to be read like a hash

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -77,8 +77,8 @@ module Raven
     # @example
     #   evt = Raven::Event.new(:message => "An error")
     #   Raven.send_event(evt)
-    def send_event(event)
-      client.send_event(event)
+    def send_event(event, hint = nil)
+      client.send_event(event, hint)
     end
 
     # Capture and process any exceptions from the given block.
@@ -120,10 +120,10 @@ module Raven
             configuration.async.call(evt.to_json_compatible)
           rescue => ex
             logger.error("async event sending failed: #{ex.message}")
-            send_event(evt)
+            send_event(evt, obj)
           end
         else
-          send_event(evt)
+          send_event(evt, obj)
         end
         Thread.current["sentry_#{object_id}_last_event_id".to_sym] = evt.id
         evt

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -120,10 +120,10 @@ module Raven
             configuration.async.call(evt.to_json_compatible)
           rescue => ex
             logger.error("async event sending failed: #{ex.message}")
-            send_event(evt, obj)
+            send_event(evt, make_hint(obj))
           end
         else
-          send_event(evt, obj)
+          send_event(evt, make_hint(obj))
         end
         Thread.current["sentry_#{object_id}_last_event_id".to_sym] = evt.id
         evt
@@ -216,6 +216,10 @@ module Raven
           capture_type(exception, options)
         end
       end
+    end
+
+    def make_hint(obj)
+      obj.is_a?(String) ? { :exception => nil, :message => obj } : { :exception => obj, :message => nil }
     end
   end
 end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe Raven::Configuration do
     expect { subject.should_capture = true }.to raise_error(ArgumentError)
   end
 
+  it 'should raise when setting before_send to anything other than callable or false' do
+    subject.before_send = -> {}
+    subject.before_send = false
+    expect { subject.before_send = true }.to raise_error(ArgumentError)
+  end
+
   context 'being initialized with a current environment' do
     before(:each) do
       subject.current_environment = 'test'

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Raven::Instance do
     describe 'as #capture_message' do
       before do
         expect(Raven::Event).to receive(:from_message).with(message, options)
-        expect(subject).to receive(:send_event).with(event, message)
+        expect(subject).to receive(:send_event).with(event, { :exception => nil, :message => message })
       end
       let(:message) { "Test message" }
 
@@ -80,14 +80,14 @@ RSpec.describe Raven::Instance do
 
       it 'sends the result of Event.capture_exception' do
         expect(Raven::Event).to receive(:from_exception).with(exception, options)
-        expect(subject).to receive(:send_event).with(event, exception)
+        expect(subject).to receive(:send_event).with(event, { :exception => exception, :message => nil })
 
         subject.capture_exception(exception, options)
       end
 
       it 'has an alias' do
         expect(Raven::Event).to receive(:from_exception).with(exception, options)
-        expect(subject).to receive(:send_event).with(event, exception)
+        expect(subject).to receive(:send_event).with(event, { :exception => exception, :message => nil })
 
         subject.capture_exception(exception, options)
       end
@@ -223,7 +223,7 @@ RSpec.describe Raven::Instance do
     let(:message) { "Test message" }
 
     it 'sends the result of Event.capture_type' do
-      expect(subject).to receive(:send_event).with(event, message)
+      expect(subject).to receive(:send_event).with(event, { :exception => nil, :message => message })
 
       subject.capture_type("Test message", options)
 

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Raven::Instance do
     describe 'as #capture_message' do
       before do
         expect(Raven::Event).to receive(:from_message).with(message, options)
-        expect(subject).to receive(:send_event).with(event, { :exception => nil, :message => message })
+        expect(subject).to receive(:send_event).with(event, :exception => nil, :message => message)
       end
       let(:message) { "Test message" }
 
@@ -80,14 +80,14 @@ RSpec.describe Raven::Instance do
 
       it 'sends the result of Event.capture_exception' do
         expect(Raven::Event).to receive(:from_exception).with(exception, options)
-        expect(subject).to receive(:send_event).with(event, { :exception => exception, :message => nil })
+        expect(subject).to receive(:send_event).with(event, :exception => exception, :message => nil)
 
         subject.capture_exception(exception, options)
       end
 
       it 'has an alias' do
         expect(Raven::Event).to receive(:from_exception).with(exception, options)
-        expect(subject).to receive(:send_event).with(event, { :exception => exception, :message => nil })
+        expect(subject).to receive(:send_event).with(event, :exception => exception, :message => nil)
 
         subject.capture_exception(exception, options)
       end
@@ -223,7 +223,7 @@ RSpec.describe Raven::Instance do
     let(:message) { "Test message" }
 
     it 'sends the result of Event.capture_type' do
-      expect(subject).to receive(:send_event).with(event, { :exception => nil, :message => message })
+      expect(subject).to receive(:send_event).with(event, :exception => nil, :message => message)
 
       subject.capture_type("Test message", options)
 

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Raven::Instance do
     describe 'as #capture_message' do
       before do
         expect(Raven::Event).to receive(:from_message).with(message, options)
-        expect(subject).to receive(:send_event).with(event)
+        expect(subject).to receive(:send_event).with(event, message)
       end
       let(:message) { "Test message" }
 
@@ -80,14 +80,14 @@ RSpec.describe Raven::Instance do
 
       it 'sends the result of Event.capture_exception' do
         expect(Raven::Event).to receive(:from_exception).with(exception, options)
-        expect(subject).to receive(:send_event).with(event)
+        expect(subject).to receive(:send_event).with(event, exception)
 
         subject.capture_exception(exception, options)
       end
 
       it 'has an alias' do
         expect(Raven::Event).to receive(:from_exception).with(exception, options)
-        expect(subject).to receive(:send_event).with(event)
+        expect(subject).to receive(:send_event).with(event, exception)
 
         subject.capture_exception(exception, options)
       end
@@ -223,7 +223,7 @@ RSpec.describe Raven::Instance do
     let(:message) { "Test message" }
 
     it 'sends the result of Event.capture_type' do
-      expect(subject).to receive(:send_event).with(event)
+      expect(subject).to receive(:send_event).with(event, message)
 
       subject.capture_type("Test message", options)
 

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -56,17 +56,50 @@ RSpec.describe "Integration tests" do
     expect(@io.string).to match(/OK!$/)
   end
 
-  it "define before_send and change event before sending" do
-    @stubs.post('/prefix/sentry/api/42/store/') { [200, {}, 'ok'] }
+  describe '#before_send' do
+    it "change event before sending (capture_exception)" do
+      @stubs.post('/prefix/sentry/api/42/store/') { [200, {}, 'ok'] }
 
-    @instance.configuration.server = 'http://12345:67890@sentry.localdomain/prefix/sentry/42'
-    @instance.configuration.before_send = lambda { |event, _hint|
-      event[:environment] = 'test'
-      event
-    }
+      @instance.configuration.server = 'http://12345:67890@sentry.localdomain/prefix/sentry/42'
+      @instance.configuration.before_send = lambda { |event, hint|
+        expect(hint[:exception]).not_to be nil
+        expect(hint[:message]).to be nil
+        event.environment = 'testxx'
+        event
+      }
 
-    @instance.capture_exception(build_exception)
+      event = @instance.capture_exception(build_exception)
+      expect(event.environment).to eq('testxx')
 
-    @stubs.verify_stubbed_calls
+      @stubs.verify_stubbed_calls
+    end
+
+    it "change event before sending (capture_message)" do
+      @stubs.post('/prefix/sentry/api/42/store/') { [200, {}, 'ok'] }
+
+      @instance.configuration.server = 'http://12345:67890@sentry.localdomain/prefix/sentry/42'
+      @instance.configuration.before_send = lambda { |event, hint|
+        expect(hint[:exception]).to be nil
+        expect(hint[:message]).not_to be nil
+        expect(event.message).to eq('xyz')
+        event.message = 'abc'
+        event
+      }
+
+      event = @instance.capture_message('xyz')
+      expect(event.message).to eq('abc')
+
+      @stubs.verify_stubbed_calls
+    end
+
+    it "return nil" do
+      @instance.configuration.server = 'http://12345:67890@sentry.localdomain/prefix/sentry/42'
+      @instance.configuration.before_send = lambda { |_event, _hint|
+        nil
+      }
+
+      @instance.capture_exception(build_exception)
+      expect(@instance.client.transport).to receive(:send_event).exactly(0)
+    end
   end
 end

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -55,4 +55,18 @@ RSpec.describe "Integration tests" do
     @instance.capture_exception(build_exception)
     expect(@io.string).to match(/OK!$/)
   end
+
+  it "define before_send and change event before sending" do
+    @stubs.post('/prefix/sentry/api/42/store/') { [200, {}, 'ok'] }
+
+    @instance.configuration.server = 'http://12345:67890@sentry.localdomain/prefix/sentry/42'
+    @instance.configuration.before_send = lambda { |event, hint|
+      event[:environment] = 'test'
+      event
+    }
+
+    @instance.capture_exception(build_exception)
+
+    @stubs.verify_stubbed_calls
+  end
 end

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Integration tests" do
     @stubs.post('/prefix/sentry/api/42/store/') { [200, {}, 'ok'] }
 
     @instance.configuration.server = 'http://12345:67890@sentry.localdomain/prefix/sentry/42'
-    @instance.configuration.before_send = lambda { |event, hint|
+    @instance.configuration.before_send = lambda { |event, _hint|
       event[:environment] = 'test'
       event
     }


### PR DESCRIPTION
This PR adds support for `before_send` like it's defined in the unified API.
ref: https://docs.sentry.io/error-reporting/configuration/filtering/?platform=javascript#before-send