### PR TITLE
Fix typo in CHANGELOG

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 2.8.0
 -----
 
-* FEATURE: Added `config.before_send`. Provide a lambda or proc to this config setting, which will be `call`ed when before sending an event to Sentry. Receives `event` and `hint` as parameter. `hint` is a has {:exception => ex | nil, :message => message | nil}. [@hazat, #882]
+* FEATURE: Added `config.before_send`. Provide a lambda or proc to this config setting, which will be `call`ed before sending an event to Sentry. Receives `event` and `hint` as parameters. `hint` is a hash `{:exception => ex | nil, :message => message | nil}`. [@hazat, #882]
 
 2.7.4
 -----

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 2.8.0
 -----
 
-* FEATURE: Added `config.before_send`. Provide a lambda or proc to this config setting, which will be `call`ed when before sending an event to Sentry. Receives `event` and `hint` as parameter. `hint` is a has {:exception => ex | nil, :message => message | nil}. [@hazat, #847]
+* FEATURE: Added `config.before_send`. Provide a lambda or proc to this config setting, which will be `call`ed when before sending an event to Sentry. Receives `event` and `hint` as parameter. `hint` is a has {:exception => ex | nil, :message => message | nil}. [@hazat, #882]
 
 2.7.4
 -----


### PR DESCRIPTION
`before_send` is add at #882