### PR TITLE
Prepend the transaction around_action so libraries with controllers can alter the value

### DIFF
--- a/lib/raven/integrations/rails/controller_transaction.rb
+++ b/lib/raven/integrations/rails/controller_transaction.rb
@@ -2,7 +2,7 @@ module Raven
   class Rails
     module ControllerTransaction
       def self.included(base)
-        base.around_action do |controller, block|
+        base.prepend_around_action do |controller, block|
           Raven.context.transaction.push "#{controller.class}##{controller.action_name}"
           block.call
           Raven.context.transaction.pop


### PR DESCRIPTION
For gems that define controllers, the following code:

```ruby
initializer 'raven.action_controller' do
  ActiveSupport.on_load :action_controller do
    ...
    include Raven::Rails::ControllerTransaction
    ...
  end
end
```

Runs after the controller (and any related `*_actions`) are defined and prevents that controller from being able to change the transaction. By prepending the `around_action`, the transaction is correctly set before any code in that controller runs and allows that controller to change the transaction.