### PR TITLE
Fix crash when Process.wait is used

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -100,7 +100,7 @@ module Raven
 
     def sys_command(command)
       result = `#{command} 2>&1` rescue nil
-      return if result.nil? || result.empty? || $CHILD_STATUS.exitstatus != 0
+      return if result.nil? || result.empty? || ($CHILD_STATUS && $CHILD_STATUS.exitstatus != 0)
       result.strip
     end
   end

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -111,5 +111,10 @@ RSpec.describe Raven do
       expect { Raven.sys_command("asdasdasdsa") }.to_not output.to_stdout
       expect { Raven.sys_command("uname -c") }.to_not output.to_stdout
     end
+
+    it "should tolerate a missing $CHILD_STATUS" do
+      trap('CLD', 'IGNORE')
+      expect(Raven.sys_command("echo 'Sentry'")).to eq("Sentry")
+    end
   end
 end

--- a/spec/raven/raven_spec.rb
+++ b/spec/raven/raven_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Raven do
     end
 
     it "should tolerate a missing $CHILD_STATUS" do
-      trap('CLD', 'IGNORE')
+      Signal.trap('CLD', 'DEFAULT')
       expect(Raven.sys_command("echo 'Sentry'")).to eq("Sentry")
     end
   end


### PR DESCRIPTION
Make `sys_command` tolerate a missing $CHILD_STATUS.

Hi 👋 in my code I was using `Process.wait` and found that it was causing this error in sentry-raven: `undefined method `exitstatus' for nil:NilClass`

My understanding is that calling `Process.wait` clears out the ruby global for last child process, and this is causing the error. I think that sentry-raven should be able to work if I use `Process.wait` or something similar like `trap('CLD', 'IGNORE') so I made a PR that I think will fix the issue. Hope that this helps 👍.