### PR TITLE
add support for SENTRY_ENVIRONMENT

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -453,7 +453,7 @@ module Raven
     end
 
     def current_environment_from_env
-      ENV['SENTRY_CURRENT_ENV'] || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'default'
+      ENV['SENTRY_CURRENT_ENV'] || ENV['SENTRY_ENVIRONMENT'] || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'default'
     end
 
     def server_name_from_env

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Raven::Configuration do
     # Make sure we reset the env in case something leaks in
     ENV.delete('SENTRY_DSN')
     ENV.delete('SENTRY_CURRENT_ENV')
+    ENV.delete('SENTRY_ENVIRONMENT')
     ENV.delete('RAILS_ENV')
     ENV.delete('RACK_ENV')
   end
@@ -85,20 +86,32 @@ RSpec.describe Raven::Configuration do
   end
 
   context 'being initialized without a current environment' do
+    after do
+      ENV.delete('SENTRY_CURRENT_ENV')
+      ENV.delete('SENTRY_ENVIRONMENT')
+      ENV.delete('RAILS_ENV')
+      ENV.delete('RACK_ENV')
+    end
+
     it 'defaults to "default"' do
       expect(subject.current_environment).to eq('default')
     end
 
     it 'uses `SENTRY_CURRENT_ENV` env variable' do
       ENV['SENTRY_CURRENT_ENV'] = 'set-with-sentry-current-env'
+      ENV['SENTRY_ENVIRONMENT'] = 'set-with-sentry-environment'
       ENV['RAILS_ENV'] = 'set-with-rails-env'
       ENV['RACK_ENV'] = 'set-with-rack-env'
 
       expect(subject.current_environment).to eq('set-with-sentry-current-env')
+    end
 
-      ENV.delete('SENTRY_CURRENT_ENV')
-      ENV.delete('RAILS_ENV')
-      ENV.delete('RACK_ENV')
+    it 'uses `SENTRY_ENVIRONMENT` env variable' do
+      ENV['SENTRY_ENVIRONMENT'] = 'set-with-sentry-environment'
+      ENV['RAILS_ENV'] = 'set-with-rails-env'
+      ENV['RACK_ENV'] = 'set-with-rack-env'
+
+      expect(subject.current_environment).to eq('set-with-sentry-environment')
     end
 
     it 'uses `RAILS_ENV` env variable' do
@@ -107,10 +120,6 @@ RSpec.describe Raven::Configuration do
       ENV['RACK_ENV'] = 'set-with-rack-env'
 
       expect(subject.current_environment).to eq('set-with-rails-env')
-
-      ENV.delete('SENTRY_CURRENT_ENV')
-      ENV.delete('RAILS_ENV')
-      ENV.delete('RACK_ENV')
     end
 
     it 'uses `RACK_ENV` env variable' do
@@ -119,10 +128,6 @@ RSpec.describe Raven::Configuration do
       ENV['RACK_ENV'] = 'set-with-rack-env'
 
       expect(subject.current_environment).to eq('set-with-rack-env')
-
-      ENV.delete('SENTRY_CURRENT_ENV')
-      ENV.delete('RAILS_ENV')
-      ENV.delete('RACK_ENV')
     end
   end
 


### PR DESCRIPTION
Fixes #901 .
Is compatible with previous configurations by giving precedence to already defined `SENTRY_CURRENT_ENV` environment variables, therefore it does not introduce a breaking change.