### PR TITLE
Logger can take in exceptions so stringify first

### DIFF
--- a/lib/raven/breadcrumbs/logger.rb
+++ b/lib/raven/breadcrumbs/logger.rb
@@ -36,7 +36,7 @@ module Raven
 
       # some loggers will add leading/trailing space as they (incorrectly, mind you)
       # think of logging as a shortcut to std{out,err}
-      message = message.strip
+      message = message.to_s.strip
 
       last_crumb = Raven.breadcrumbs.peek
       # try to avoid dupes from logger broadcasts

--- a/spec/raven/logger_spec.rb
+++ b/spec/raven/logger_spec.rb
@@ -9,4 +9,13 @@ RSpec.describe Raven::Logger do
 
     expect(stringio.string).to end_with("FATAL -- sentry: ** [Raven] Oh noes!\n")
   end
+
+  it "should allow exceptions to be logged" do
+    stringio = StringIO.new
+    log = Raven::Logger.new(stringio)
+
+    log.fatal(Exception.new("Oh exceptions"))
+
+    expect(stringio.string).to end_with("FATAL -- sentry: ** [Raven] Oh exceptions\n")
+  end
 end


### PR DESCRIPTION
According to https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html\#method-i-add-label-Args