### PR TITLE
feat: Allow block on tags_context and extra_context

### DIFF
--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -183,6 +183,9 @@ module Raven
     #   Raven.tags_context('my_custom_tag' => 'tag_value')
     def tags_context(options = nil)
       context.tags.merge!(options || {})
+      yield if block_given?
+    ensure
+      context.tags.delete_if { |k, _| options.keys.include? k } if block_given?
     end
 
     # Bind extra context. Merges with existing context (if any).
@@ -194,6 +197,9 @@ module Raven
     #   Raven.extra_context('my_custom_data' => 'value')
     def extra_context(options = nil)
       context.extra.merge!(options || {})
+      yield if block_given?
+    ensure
+      context.extra.delete_if { |k, _| options.keys.include? k } if block_given?
     end
 
     def rack_context(env)

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -231,6 +231,62 @@ RSpec.describe Raven::Instance do
     end
   end
 
+  describe "#tags_context" do
+    let(:default) { { :foo => :bar } }
+    let(:additional) { { :baz => :qux } }
+
+    before do
+      subject.context.tags = default
+    end
+
+    it "doesn't set anything if the tags is empty" do
+      subject.tags_context({})
+      expect(subject.context.tags).to eq default
+    end
+
+    it "adds tags" do
+      subject.tags_context(additional)
+      expect(subject.context.tags).to eq default.merge(additional)
+    end
+
+    context 'when block given' do
+      it "adds tags only in the block" do
+        subject.tags_context(additional) do
+          expect(subject.context.tags).to eq default.merge(additional)
+        end
+        expect(subject.context.tags).to eq default
+      end
+    end
+  end
+
+  describe "#extra_context" do
+    let(:default) { { :foo => :bar } }
+    let(:additional) { { :baz => :qux } }
+
+    before do
+      subject.context.extra = default
+    end
+
+    it "doesn't set anything if the extra is empty" do
+      subject.extra_context({})
+      expect(subject.context.extra).to eq default
+    end
+
+    it "adds extra" do
+      subject.extra_context(additional)
+      expect(subject.context.extra).to eq default.merge(additional)
+    end
+
+    context 'when block given' do
+      it "adds extra only in the block" do
+        subject.extra_context(additional) do
+          expect(subject.context.extra).to eq default.merge(additional)
+        end
+        expect(subject.context.extra).to eq default
+      end
+    end
+  end
+
   describe "#rack_context" do
     it "doesn't set anything if the context is empty" do
       subject.rack_context({})


### PR DESCRIPTION
This makes `tags_context` and `extra_context` block receivable and it defines a scope for the tags/extra.

Before:

```ruby
posts.each do |post|
  Raven.tags_context(post_id: post.id)
  # do something
end
Raven.context.tags.delete(:post_id)
```

After:

```ruby
posts.each do |post|
  Raven.tags_context(post_id: post.id) do
    # do something
  end
end
```