### PR TITLE
Fix frozen string bug in utf8conversation

### DIFF
--- a/lib/raven/processor/utf8conversion.rb
+++ b/lib/raven/processor/utf8conversion.rb
@@ -39,7 +39,7 @@ module Raven
     # https://github.com/rspec/rspec-support/blob/f0af3fd74a94ff7bb700f6ba06dbdc67bba17fbf/lib/rspec/support/encoded_string.rb#L120-L139
     if String.method_defined?(:scrub) # 2.1+
       def remove_invalid_bytes(string)
-        string.scrub!(REPLACE)
+        string.scrub(REPLACE)
       end
     else
       def remove_invalid_bytes(string)


### PR DESCRIPTION
Instead of mutating the string in `remove_invalid_bytes` simply return a new string.

Fixes the following exception:

```
FrozenError: can't modify frozen String 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:42:in `scrub!' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:42:in `remove_invalid_bytes' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:30:in `process' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:12:in `block in process' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:12:in `merge!' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:12:in `process' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:14:in `block in process' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:14:in `map!' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:14:in `process' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:12:in `block in process' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:12:in `merge!' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:12:in `process' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:12:in `block in process' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:12:in `merge!' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/processor/utf8conversion.rb:12:in `process' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/client.rb:71:in `block in encode' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/client.rb:71:in `each' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/client.rb:71:in `reduce' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/client.rb:71:in `encode' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/client.rb:40:in `send_event' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/instance.rb:81:in `send_event' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/instance.rb:123:in `rescue in capture_type' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/instance.rb:117:in `capture_type' 
 /usr/local/rvm/rubies/ruby-2.6.4/lib/ruby/2.6.0/forwardable.rb:230:in `capture_exception' 
 /bundle/ruby/2.6.0/gems/sentry-raven-2.9.0/lib/raven/integrations/rake.rb:9:in `display_error_message' 
 /bundle/ruby/2.6.0/gems/rake-11.3.0/lib/rake/application.rb:187:in `rescue in standard_exception_handling' 
 /bundle/ruby/2.6.0/gems/rake-11.3.0/lib/rake/application.rb:177:in `standard_exception_handling'  
```