### PR TITLE
feat: remove message duplicate

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -59,10 +59,7 @@ module Raven
       return unless configuration.exception_class_allowed?(exc)
 
       new(options) do |evt|
-        evt.message = "#{exc.class}: #{exc.message}"
-
         evt.add_exception_interface(exc)
-
         yield evt if block
       end
     end


### PR DESCRIPTION
We currently send both message and exception. That causes data to render pretty ugly: https://images.ctfassets.net/em6l9zw4tzag/4m9DxRpO6SfX5GsKE2Ol9m/b55cceec22b9e1042736e298a5c958af/simple-error.png

(i did not test this)