### PR TITLE
fix: return tags/extra for #931

### DIFF
--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -184,6 +184,7 @@ module Raven
     def tags_context(options = nil)
       context.tags.merge!(options || {})
       yield if block_given?
+      context.tags
     ensure
       context.tags.delete_if { |k, _| options.keys.include? k } if block_given?
     end
@@ -198,6 +199,7 @@ module Raven
     def extra_context(options = nil)
       context.extra.merge!(options || {})
       yield if block_given?
+      context.extra
     ensure
       context.extra.delete_if { |k, _| options.keys.include? k } if block_given?
     end

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -239,6 +239,14 @@ RSpec.describe Raven::Instance do
       subject.context.tags = default
     end
 
+    it "returns the tags" do
+      expect(subject.tags_context).to eq default
+    end
+
+    it "returns the tags" do
+      expect(subject.tags_context(additional)).to eq default.merge(additional)
+    end
+
     it "doesn't set anything if the tags is empty" do
       subject.tags_context({})
       expect(subject.context.tags).to eq default
@@ -250,6 +258,13 @@ RSpec.describe Raven::Instance do
     end
 
     context 'when block given' do
+      it "returns the tags" do
+        tags = subject.tags_context(additional) do
+          # do nothing
+        end
+        expect(tags).to eq default
+      end
+
       it "adds tags only in the block" do
         subject.tags_context(additional) do
           expect(subject.context.tags).to eq default.merge(additional)
@@ -267,6 +282,14 @@ RSpec.describe Raven::Instance do
       subject.context.extra = default
     end
 
+    it "returns the extra" do
+      expect(subject.extra_context).to eq default
+    end
+
+    it "returns the extra" do
+      expect(subject.extra_context(additional)).to eq default.merge(additional)
+    end
+
     it "doesn't set anything if the extra is empty" do
       subject.extra_context({})
       expect(subject.context.extra).to eq default
@@ -278,6 +301,13 @@ RSpec.describe Raven::Instance do
     end
 
     context 'when block given' do
+      it "returns the extra" do
+        extra = subject.extra_context(additional) do
+          # do nothing
+        end
+        expect(extra).to eq default
+      end
+
       it "adds extra only in the block" do
         subject.extra_context(additional) do
           expect(subject.context.extra).to eq default.merge(additional)


### PR DESCRIPTION
For https://github.com/getsentry/raven-ruby/issues/931,

Fixed and added specs to keep the return value of `tags_context` and `tags_extra` which has been broken by https://github.com/getsentry/raven-ruby/pull/920.