### PR TITLE
Fix serialization MongoDB ObjectId to JSON problem with gem delayed_job_mongoid conjunction

### DIFF
--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -13,7 +13,7 @@ module Delayed
             # Log error to Sentry
             extra = {
               :delayed_job => {
-                :id          => job.id,
+                :id          => job.id.to_s,
                 :priority    => job.priority,
                 :attempts    => job.attempts,
                 :run_at      => job.run_at,
@@ -36,7 +36,7 @@ module Delayed
                                       :logger  => 'delayed_job',
                                       :tags    => {
                                         :delayed_job_queue => job.queue,
-                                        :delayed_job_id => job.id
+                                        :delayed_job_id => job.id.to_s
                                       },
                                       :extra => extra)
 


### PR DESCRIPTION
Before exceptions happen in Delayed Job worker serialize its ID in JSON as:
  "extra": {
    "delayed_job": {
      "id": 5db2b8ca1f38707f65dd8da5,
      ...
    }
  "tags": {
    "delayed_job_queue": "default",
    "delayed_job_id": 5db2b8ca1f38707f65dd8da5
  }

But JSON does not support hexadecimal numbers. Then error happen on Sentry server side:

  Raven::Error: the server responded with status 400 Error in headers is: Bad data reconstructing
  object (JSONDecodeError, Expecting ',' delimiter or '}': line 1 column 508 (char 507))

For fix this just convert hex ObjectId to string.