### PR TITLE
Sanitize event data before they are sent to async job.

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -228,10 +228,7 @@ module Raven
     end
 
     def async_json_processors
-      [
-        Raven::Processor::RemoveCircularReferences,
-        Raven::Processor::UTF8Conversion
-      ].map { |v| v.new(self) }
+      configuration.processors.map { |v| v.new(self) }
     end
 
     def list_gem_specs

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe Raven::Event do
                          })
       end
 
-      it "should saniztize password" do
+      it "should sanitize password" do
         json = subject.to_json_compatible
 
         expect(json["extra"]["password"]).to eq(Raven::Processor::SanitizeData::STRING_MASK)

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -409,6 +409,20 @@ RSpec.describe Raven::Event do
         expect(json["extra"]["circular"]["ary2"]).to eq("(...)")
       end
     end
+
+    context "with sensitive data" do
+      subject do
+        Raven::Event.new(:extra => {
+                           'password' => 'secretpassword'
+                         })
+      end
+
+      it "should saniztize password" do
+        json = subject.to_json_compatible
+
+        expect(json["extra"]["password"]).to eq(Raven::Processor::SanitizeData::STRING_MASK)
+      end
+    end
   end
 
   describe '.capture_message' do


### PR DESCRIPTION
All of the error parameters should be sanitized before they are passed to the async job.

When sentry is configured to send data asynchronously, all the data passed to the async job are not sanitized. This can cause potential security problems. If you are using background job processing to send data to sentry, unsanitized parameters are send to the background job and sometimes they are logged to the application log.

Eg. ActiveJob is logging all of the data captured by sentry, currently including **passwords, tokens, cookies, Authorization headers, etc.**. Sanitization is done during background job processing just before data are sent to Sentry.

Changes proposed by this pull request should fix it.