### PR TITLE
CI: Use jruby-9.2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ matrix:
       env: RAILS_VERSION=4
     - rvm: jruby-1.7.27
       env: JRUBY_OPTS="--dev" RAILS_VERSION=4
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2.9.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M" RAILS_VERSION=4
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2.9.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M" RAILS_VERSION=5
     - rvm: ruby-head
       env: RAILS_VERSION=0


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.9.0**.

[JRuby 9.2.9.0 release blog post](https://www.jruby.org/2019/10/30/jruby-9-2-9-0.html)