### PR TITLE
Fix bugs with send_event in asynchronous mode

### DIFF
--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -35,7 +35,8 @@ module Raven
         return
       end
 
-      configuration.logger.info "Sending event #{event[:event_id]} to Sentry"
+      event_id = event[:event_id] || event['event_id']
+      configuration.logger.info "Sending event #{event_id} to Sentry"
 
       content_type, encoded_data = encode(event)
 

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -93,7 +93,7 @@ module Raven
     end
 
     def get_log_message(event)
-      (event && event[:message]) || get_message_from_exception(event) || '<no message value>'
+      (event && event[:message]) || (event && event['message']) || get_message_from_exception(event) || '<no message value>'
     end
 
     def generate_auth_header


### PR DESCRIPTION
When running Raven asynchronously, we call `to_json_compatible` on `event` which results in all of the keys of the `event` hash being Strings, not Symbols. So `event[:event_id]` will return `nil` and the log won't have the `event_id`. Similarly, `send_event` can (indirectly) call ` get_log_message` which also assumes the keys to the hash are Symbols. This PR adds checks for when the keys are Strings.