### PR TITLE
Make get_message_from_exception a public method

### DIFF
--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -66,6 +66,18 @@ module Raven
         end
     end
 
+    def get_message_from_exception(event)
+      (
+        event &&
+        event[:exception] &&
+        event[:exception][:values] &&
+        event[:exception][:values][0] &&
+        event[:exception][:values][0][:type] &&
+        event[:exception][:values][0][:value] &&
+        "#{event[:exception][:values][0][:type]}: #{event[:exception][:values][0][:value]}"
+      )
+    end
+
     private
 
     def encode(event)
@@ -78,18 +90,6 @@ module Raven
       else
         ['application/json', encoded]
       end
-    end
-
-    def get_message_from_exception(event)
-      (
-        event &&
-        event[:exception] &&
-        event[:exception][:values] &&
-        event[:exception][:values][0] &&
-        event[:exception][:values][0][:type] &&
-        event[:exception][:values][0][:value] &&
-        "#{event[:exception][:values][0][:type]}: #{event[:exception][:values][0][:value]}"
-      )
     end
 
     def get_log_message(event)


### PR DESCRIPTION
As of #928, `Event`s no longer expose a `message` attribute. For code
that relied on using `message`, it's cumbersome to now have to do this
whole nil-checking chain every time. It would be nice if instead we
could use the already existing `get_message_from_exception` method to
handle this for us.