### PR TITLE
Replace unnecessary shell exec to get Ruby version info

### DIFF
--- a/lib/raven/context.rb
+++ b/lib/raven/context.rb
@@ -35,7 +35,7 @@ module Raven
       def runtime_context
         @runtime_context ||= {
           :name => RbConfig::CONFIG["ruby_install_name"],
-          :version => Raven.sys_command("ruby -v")
+          :version => RUBY_DESCRIPTION || Raven.sys_command("ruby -v")
         }
       end
     end


### PR DESCRIPTION
In [issue #943 sub-point #2](https://github.com/getsentry/raven-ruby/issues/943), it was identified that using RUBY_DESCRIPTION returns the same thing as `ruby -v` does for all currently supported Ruby versions. This change fixes that sub-point and provides a fallback to the old method in the event it fails as a safety precaution.