### PR TITLE
Bump faraday version to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
   only: [master]
 
 rvm:
-  - 2.2.10
   - 2.3.8
   - 2.4.9
   - 2.5.7
@@ -33,10 +32,6 @@ before_install:
 
 matrix:
   include:
-    - rvm: 1.9
-      env: RAILS_VERSION=4
-    - rvm: jruby-1.7.27
-      env: JRUBY_OPTS="--dev" RAILS_VERSION=4
     - rvm: jruby-9.2.9.0
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M" RAILS_VERSION=4
     - rvm: jruby-9.2.9.0

--- a/sentry-raven.gemspec
+++ b/sentry-raven.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.bindir = "exe"
   gem.executables = "raven"
 
-  gem.add_dependency "faraday", ">= 0.7.6", "< 1.0"
+  gem.add_dependency "faraday", ">= 1.0"
 end

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Integration tests" do
   # end
 
   it "timed backoff should prevent sends" do
-    expect(@instance.client.transport).to receive(:send_event).exactly(1).times.and_raise(Faraday::Error::ConnectionFailed, "conn failed")
+    expect(@instance.client.transport).to receive(:send_event).exactly(1).times.and_raise(Faraday::ConnectionFailed, "conn failed")
     2.times { @instance.capture_exception(build_exception) }
     expect(@io.string).to match(/Failed to submit event: ZeroDivisionError: divided by 0$/)
   end
@@ -51,7 +51,7 @@ RSpec.describe "Integration tests" do
   it "transport failure should call transport_failure_callback" do
     @instance.configuration.transport_failure_callback = proc { |_e| @io.puts "OK!" }
 
-    expect(@instance.client.transport).to receive(:send_event).exactly(1).times.and_raise(Faraday::Error::ConnectionFailed, "conn failed")
+    expect(@instance.client.transport).to receive(:send_event).exactly(1).times.and_raise(Faraday::ConnectionFailed, "conn failed")
     @instance.capture_exception(build_exception)
     expect(@io.string).to match(/OK!$/)
   end


### PR DESCRIPTION
Bumping required faraday version to v1.0.0 from v0.7.6. This requires dropping support for Ruby 2.2 - but fixes Ruby 2.7. For details see:
    
https://github.com/lostisland/faraday/blob/master/CHANGELOG.md#v10
