### PR TITLE
Retain any literal "HTTP-" in header names

### DIFF
--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -113,7 +113,7 @@ module Raven
 
           next unless key.start_with?('HTTP_') || %w(CONTENT_TYPE CONTENT_LENGTH).include?(key)
           # Rack stores headers as HTTP_WHAT_EVER, we need What-Ever
-          key = key.gsub("HTTP_", "")
+          key = key.sub(/^HTTP_/, "")
           key = key.split('_').map(&:capitalize).join('-')
           memo[key] = value
         rescue StandardError => e

--- a/spec/raven/integrations/rack_spec.rb
+++ b/spec/raven/integrations/rack_spec.rb
@@ -103,6 +103,14 @@ RSpec.describe Raven::Rack do
     expect(interface.headers["Version"]).to eq("HTTP/2.0")
   end
 
+  it 'retains any literal "HTTP-" in the actual header name' do
+    interface = Raven::HttpInterface.new
+    new_env = env.merge("HTTP_HTTP_CUSTOM_HTTP_HEADER" => "test")
+    interface.from_rack(new_env)
+
+    expect(interface.headers).to include("Http-Custom-Http-Header" => "test")
+  end
+
   it 'does not fail if an object in the env cannot be cast to string' do
     obj = Class.new do
       def to_s


### PR DESCRIPTION
If a literal `HTTP-` exists in a request header name, it will appear as `HTTP_` in the Rack environment. This shouldn't be removed when extracting it from the environment.