### PR TITLE
Circular references processor should not change user data

### DIFF
--- a/lib/raven/processor/removecircularreferences.rb
+++ b/lib/raven/processor/removecircularreferences.rb
@@ -6,9 +6,9 @@ module Raven
 
       case value
       when Hash
-        !value.frozen? ? value.merge!(value) { |_, v| process v, visited } : value.merge(value) { |_, v| process v, visited }
+        value.merge(value) { |_, v| process v, visited }
       when Array
-        !value.frozen? ? value.map! { |v| process v, visited } : value.map { |v| process v, visited }
+        value.map { |v| process v, visited }
       else
         value
       end


### PR DESCRIPTION
I understand that it's not memory-efficient, but you are working with business rules which might rely on references.
Consider opting out this behavior, or display a warning somewhere, and this behavior should be documented. 
I spent 6 hours of debugging code because of the sentry event. Imagine my feelings when I figure out it's caused by raven.