### PR TITLE
Improve DSN section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We test on Ruby 2.3, 2.4, 2.5, 2.6 and 2.7 at the latest patchlevel/teeny versio
 gem "sentry-raven"
 ```
 
-### Raven only runs when SENTRY_DSN is set
+### Raven only runs when Sentry DSN is set
 
 Raven will capture and send exceptions to the Sentry server whenever its DSN is set. This makes environment-based configuration easy - if you don't want to send errors in a certain environment, just don't set the DSN in that environment!
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Raven will capture and send exceptions to the Sentry server whenever its DSN is 
 export SENTRY_DSN=http://public@example.com/project-id
 ```
 ```ruby
-# Or you can configure the client in the code (not recommended - keep your DSN secret!)
+# Or you can configure the client in the code.
 Raven.configure do |config|
   config.dsn = 'http://public@example.com/project-id'
 end


### PR DESCRIPTION
This PR includes 2 changes:

- Improves a confusing title in README
- Removes a confusing comment from README

The title suggests that `SENTRY_DSN` environment variable needs to be set in order for Sentry to work. That's incorrect, since there's an alternative way to configure Sentry DSN.

As far as I was able to understand, Sentry DSN value is considered public, so README should not suggest users to keep DSN private. This is especially confusing when someone is using Sentry in two clients - Ruby and JavaScript, since one of them must be public and the value is the same. So there's no way to keep the value private.