### PR TITLE
Serialize ActiveJob arguments to report global ids

### DIFF
--- a/lib/raven/integrations/rails/active_job.rb
+++ b/lib/raven/integrations/rails/active_job.rb
@@ -40,7 +40,7 @@ module Raven
       def raven_context(job)
         ctx = {
           :active_job => job.class.name,
-          :arguments => job.arguments,
+          :arguments => ActiveJob::Arguments.serialize(job.arguments),
           :scheduled_at => job.scheduled_at,
           :job_id => job.job_id,
           :locale => job.locale


### PR DESCRIPTION
Previously, a job initialized with an ActiveRecord object was reported using its string representation, which often looked like `"#<MyClass:0x00007fa3b7cc37f8>"`.

This change allows us to report ActiveJob arguments in a more useful way. Although the reported arguments make a private implementation detail visible (i.e. ActiveJob's serialization keys), it does so to be future-proof by relying on the same serialization logic as ActiveJob.