### PR TITLE
Fix #967: 'can't modify frozen String' error on Rails 5.2 and ruby 2.7.1'

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -252,7 +252,7 @@ module Raven
       self.path = uri_path.join('/')
 
       # For anyone who wants to read the base server string
-      @server = "#{scheme}://#{host}"
+      @server = "#{scheme}://#{host}".dup
       @server << ":#{port}" unless port == { 'http' => 80, 'https' => 443 }[scheme]
       @server << path
     end


### PR DESCRIPTION
This is the change I made locally to fix the FrozenError exception as I encountered it in #967 