### PR TITLE
Support different versions of sidekiq in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ rvm:
   - 2.7.0
 
 env:
-  - RAILS_VERSION=4
-  - RAILS_VERSION=5
+  - RAILS_VERSION=4 SIDEKIQ_VERSION=5
+  - RAILS_VERSION=4 SIDEKIQ_VERSION=6
+  - RAILS_VERSION=5 SIDEKIQ_VERSION=5
+  - RAILS_VERSION=5 SIDEKIQ_VERSION=6
   - RAILS_VERSION=0
 
 addons:
@@ -39,5 +41,16 @@ matrix:
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M" RAILS_VERSION=5
     - rvm: ruby-head
       env: RAILS_VERSION=0
+  exclude:
+    # sidekiq 6 requires Ruby 2.5
+    - rvm: 2.3.8
+      env: RAILS_VERSION=4 SIDEKIQ_VERSION=6
+    - rvm: 2.3.8
+      env: RAILS_VERSION=5 SIDEKIQ_VERSION=6
+    - rvm: 2.4.9
+      env: RAILS_VERSION=4 SIDEKIQ_VERSION=6
+    - rvm: 2.4.9
+      env: RAILS_VERSION=5 SIDEKIQ_VERSION=6
+
   allow_failures:
     - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,13 @@ if RUBY_VERSION < '2.0'
   gem "rack-timeout", "0.3.0"
 else
   gem "rack"
-  gem "sidekiq"
   gem "rack-timeout"
+
+  if ENV["SIDEKIQ_VERSION"].to_i >= 6 && RUBY_VERSION > '2.5'
+    gem "sidekiq", ">= 6"
+  else
+    gem "sidekiq", "< 6"
+  end
 end
 gem "pry"
 gem "pry-coolline"

--- a/spec/raven/integrations/sidekiq_spec.rb
+++ b/spec/raven/integrations/sidekiq_spec.rb
@@ -123,9 +123,15 @@ if RUBY_VERSION > '2.0'
     end
 
     before do
-      @mgr = double('manager')
+      @mgr = double('manager', :options => {})
       allow(@mgr).to receive(:options).and_return(:queues => ['default'])
-      @processor = ::Sidekiq::Processor.new(@mgr)
+
+      @processor =
+        if Sidekiq::VERSION.to_i >= 6
+          ::Sidekiq::Processor.new(@mgr, @mgr.options)
+        else
+          ::Sidekiq::Processor.new(@mgr)
+        end
     end
 
     def process_job(klass)


### PR DESCRIPTION
Sidekiq 5.x and 6.0 have different interfaces so we should test against them separately.