### PR TITLE
Remove RUBY_VERSION checks that are under Ruby 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,25 +12,18 @@ else
   gem "rspec-rails", "> 3"
 end
 
-if RUBY_VERSION < '2.0'
-  gem "mime-types", "< 3.0.0"
-  gem "nokogiri", "~> 1.6.8"
-  gem "rack", "~> 1.6.8"
-  gem "sidekiq", "< 3.2"
-  gem "rack-timeout", "0.3.0"
-else
-  gem "rack"
-  gem "rack-timeout"
+gem "rack"
+gem "rack-timeout"
 
-  if ENV["SIDEKIQ_VERSION"].to_i >= 6 && RUBY_VERSION > '2.5'
-    gem "sidekiq", ">= 6"
-  else
-    gem "sidekiq", "< 6"
-  end
+if ENV["SIDEKIQ_VERSION"].to_i >= 6 && RUBY_VERSION > '2.5'
+  gem "sidekiq", ">= 6"
+else
+  gem "sidekiq", "< 6"
 end
+
 gem "pry"
 gem "benchmark-ips"
-gem "benchmark-ipsa" if RUBY_VERSION > '2.0'
+gem "benchmark-ipsa"
 gem "ruby-prof", platform: :mri
 gem "rake", "> 12"
 gem "rubocop", "~> 0.41.1" # Last version that supported 1.9, upgrade to 0.50 after we drop 1.9
@@ -39,4 +32,4 @@ gem "capybara" # rspec system tests
 gem "puma" # rspec system tests
 
 gem "timecop"
-gem "test-unit", platform: :mri if RUBY_VERSION > '2.2'
+gem "test-unit"

--- a/spec/raven/integrations/sidekiq_spec.rb
+++ b/spec/raven/integrations/sidekiq_spec.rb
@@ -1,197 +1,195 @@
-if RUBY_VERSION > '2.0'
-  require 'spec_helper'
+require 'spec_helper'
 
-  require 'raven/integrations/sidekiq'
-  require 'sidekiq/processor'
+require 'raven/integrations/sidekiq'
+require 'sidekiq/processor'
 
-  RSpec.describe "Raven::SidekiqErrorHandler" do
-    let(:context) do
-      {
-        "args" => [true, true],
-        "class" => "HardWorker",
-        "created_at" => 1_474_922_824.910579,
-        "enqueued_at" => 1_474_922_824.910665,
-        "error_class" => "RuntimeError",
-        "error_message" => "a wild exception appeared",
-        "failed_at" => 1_474_922_825.158953,
-        "jid" => "701ed9cfa51c84a763d56bc4",
-        "queue" => "default",
-        "retry" => true,
-        "retry_count" => 0
-      }
-    end
+RSpec.describe "Raven::SidekiqErrorHandler" do
+  let(:context) do
+    {
+      "args" => [true, true],
+      "class" => "HardWorker",
+      "created_at" => 1_474_922_824.910579,
+      "enqueued_at" => 1_474_922_824.910665,
+      "error_class" => "RuntimeError",
+      "error_message" => "a wild exception appeared",
+      "failed_at" => 1_474_922_825.158953,
+      "jid" => "701ed9cfa51c84a763d56bc4",
+      "queue" => "default",
+      "retry" => true,
+      "retry_count" => 0
+    }
+  end
 
-    it "should capture exceptions based on Sidekiq context" do
+  it "should capture exceptions based on Sidekiq context" do
+    exception = build_exception
+    expected_options = {
+      :message => exception.message,
+      :extra => { :sidekiq => context }
+    }
+
+    expect(Raven).to receive(:capture_exception).with(exception, expected_options)
+
+    Raven::SidekiqErrorHandler.new.call(exception, context)
+  end
+
+  context "when the captured exception is already annotated" do
+    it "does a deep merge of options" do
       exception = build_exception
+      Raven.annotate_exception(exception, :extra => { :job_title => "engineer" })
       expected_options = {
         :message => exception.message,
-        :extra => { :sidekiq => context }
+        :extra => {
+          :sidekiq => context,
+          :job_title => "engineer"
+        }
       }
 
-      expect(Raven).to receive(:capture_exception).with(exception, expected_options)
+      expect(Raven::Event).to receive(:new).with(hash_including(expected_options))
 
       Raven::SidekiqErrorHandler.new.call(exception, context)
     end
-
-    context "when the captured exception is already annotated" do
-      it "does a deep merge of options" do
-        exception = build_exception
-        Raven.annotate_exception(exception, :extra => { :job_title => "engineer" })
-        expected_options = {
-          :message => exception.message,
-          :extra => {
-            :sidekiq => context,
-            :job_title => "engineer"
-          }
-        }
-
-        expect(Raven::Event).to receive(:new).with(hash_including(expected_options))
-
-        Raven::SidekiqErrorHandler.new.call(exception, context)
-      end
-    end
-
-    it "filters out ActiveJob keys", :rails => true do
-      exception = build_exception
-      aj_context = context
-      aj_context["_aj_globalid"] = GlobalID.new('gid://app/model/id')
-      expected_context = aj_context.dup
-      expected_context.delete("_aj_globalid")
-      expected_context["_globalid"] = "gid://app/model/id"
-      expected_options = {
-        :message => exception.message,
-        :extra => { :sidekiq => expected_context }
-      }
-      expect(Raven).to receive(:capture_exception).with(exception, expected_options)
-
-      Raven::SidekiqErrorHandler.new.call(exception, aj_context)
-    end
   end
 
-  class HappyWorker
-    include Sidekiq::Worker
+  it "filters out ActiveJob keys", :rails => true do
+    exception = build_exception
+    aj_context = context
+    aj_context["_aj_globalid"] = GlobalID.new('gid://app/model/id')
+    expected_context = aj_context.dup
+    expected_context.delete("_aj_globalid")
+    expected_context["_globalid"] = "gid://app/model/id"
+    expected_options = {
+      :message => exception.message,
+      :extra => { :sidekiq => expected_context }
+    }
+    expect(Raven).to receive(:capture_exception).with(exception, expected_options)
 
-    def perform
-      Raven.breadcrumbs.record do |crumb|
-        crumb.message = "I'm happy!"
-      end
-      Raven.tags_context :mood => 'happy'
+    Raven::SidekiqErrorHandler.new.call(exception, aj_context)
+  end
+end
+
+class HappyWorker
+  include Sidekiq::Worker
+
+  def perform
+    Raven.breadcrumbs.record do |crumb|
+      crumb.message = "I'm happy!"
     end
+    Raven.tags_context :mood => 'happy'
+  end
+end
+
+class SadWorker
+  include Sidekiq::Worker
+
+  def perform
+    Raven.breadcrumbs.record do |crumb|
+      crumb.message = "I'm sad!"
+    end
+    Raven.tags_context :mood => 'sad'
+
+    raise "I'm sad!"
+  end
+end
+
+class VerySadWorker
+  include Sidekiq::Worker
+
+  def perform
+    Raven.breadcrumbs.record do |crumb|
+      crumb.message = "I'm very sad!"
+    end
+    Raven.tags_context :mood => 'very sad'
+
+    raise "I'm very sad!"
+  end
+end
+
+class ReportingWorker
+  include Sidekiq::Worker
+
+  def perform
+    Raven.capture_message("I have something to say!")
+  end
+end
+
+RSpec.describe "Sidekiq full-stack integration" do
+  before(:all) do
+    Sidekiq.error_handlers << Raven::SidekiqErrorHandler.new
+    Sidekiq.server_middleware do |chain|
+      chain.add Raven::SidekiqCleanupMiddleware
+    end
+    Sidekiq.logger = Logger.new(nil)
   end
 
-  class SadWorker
-    include Sidekiq::Worker
+  before do
+    @mgr = double('manager', :options => {})
+    allow(@mgr).to receive(:options).and_return(:queues => ['default'])
 
-    def perform
-      Raven.breadcrumbs.record do |crumb|
-        crumb.message = "I'm sad!"
+    @processor =
+      if Sidekiq::VERSION.to_i >= 6
+        ::Sidekiq::Processor.new(@mgr, @mgr.options)
+      else
+        ::Sidekiq::Processor.new(@mgr)
       end
-      Raven.tags_context :mood => 'sad'
-
-      raise "I'm sad!"
-    end
   end
 
-  class VerySadWorker
-    include Sidekiq::Worker
+  def process_job(klass)
+    msg = Sidekiq.dump_json("class" => klass)
+    job = Sidekiq::BasicFetch::UnitOfWork.new('queue:default', msg)
+    @processor.instance_variable_set(:'@job', job)
 
-    def perform
-      Raven.breadcrumbs.record do |crumb|
-        crumb.message = "I'm very sad!"
-      end
-      Raven.tags_context :mood => 'very sad'
-
-      raise "I'm very sad!"
-    end
+    @processor.send(:process, job)
+  rescue # rubocop:disable Lint/HandleExceptions
+    # do nothing
   end
 
-  class ReportingWorker
-    include Sidekiq::Worker
+  it "actually captures an exception" do
+    redis_on = Sidekiq.redis(&:info) rescue nil
+    skip("No Redis server online") unless redis_on
 
-    def perform
-      Raven.capture_message("I have something to say!")
-    end
+    expect { process_job("SadWorker") }.to change { Raven.client.transport.events.size }.by(1)
+
+    event = JSON.parse(Raven.client.transport.events.last[1])
+    expect(event["logentry"]["message"]).to eq("I'm sad!")
   end
 
-  RSpec.describe "Sidekiq full-stack integration" do
-    before(:all) do
-      Sidekiq.error_handlers << Raven::SidekiqErrorHandler.new
-      Sidekiq.server_middleware do |chain|
-        chain.add Raven::SidekiqCleanupMiddleware
-      end
-      Sidekiq.logger = Logger.new(nil)
-    end
+  it "clears context from other workers and captures its own" do
+    process_job("HappyWorker")
+    process_job("SadWorker")
 
-    before do
-      @mgr = double('manager', :options => {})
-      allow(@mgr).to receive(:options).and_return(:queues => ['default'])
+    event = JSON.parse(Raven.client.transport.events.last[1])
 
-      @processor =
-        if Sidekiq::VERSION.to_i >= 6
-          ::Sidekiq::Processor.new(@mgr, @mgr.options)
-        else
-          ::Sidekiq::Processor.new(@mgr)
-        end
-    end
+    expect(event["tags"]).to eq("mood" => "sad")
+    expect(event["transaction"]).to eq("Sidekiq/SadWorker")
+    expect(event["breadcrumbs"]["values"][0]["message"]).to eq("I'm sad!")
+  end
 
-    def process_job(klass)
-      msg = Sidekiq.dump_json("class" => klass)
-      job = Sidekiq::BasicFetch::UnitOfWork.new('queue:default', msg)
-      @processor.instance_variable_set(:'@job', job)
+  it "clears context after raising" do
+    process_job("SadWorker")
+    process_job("VerySadWorker")
 
-      @processor.send(:process, job)
-    rescue # rubocop:disable Lint/HandleExceptions
-      # do nothing
-    end
+    event = JSON.parse(Raven.client.transport.events.last[1])
 
-    it "actually captures an exception" do
-      redis_on = Sidekiq.redis(&:info) rescue nil
-      skip("No Redis server online") unless redis_on
+    expect(event["tags"]).to eq("mood" => "very sad")
+    expect(event["breadcrumbs"]["values"][0]["message"]).to eq("I'm very sad!")
+  end
 
-      expect { process_job("SadWorker") }.to change { Raven.client.transport.events.size }.by(1)
+  it "captures exceptions raised during events" do
+    Sidekiq.options[:lifecycle_events][:startup] = [proc { raise "Uhoh!" }]
+    @processor.fire_event(:startup)
 
-      event = JSON.parse(Raven.client.transport.events.last[1])
-      expect(event["logentry"]["message"]).to eq("I'm sad!")
-    end
+    event = JSON.parse(Raven.client.transport.events.last[1])
 
-    it "clears context from other workers and captures its own" do
-      process_job("HappyWorker")
-      process_job("SadWorker")
+    expect(event["logentry"]["message"]).to eq "Uhoh!"
+    expect(event["transaction"]).to eq "Sidekiq/startup"
+  end
 
-      event = JSON.parse(Raven.client.transport.events.last[1])
+  it "has some context when capturing, even if no exception raised" do
+    process_job("ReportingWorker")
 
-      expect(event["tags"]).to eq("mood" => "sad")
-      expect(event["transaction"]).to eq("Sidekiq/SadWorker")
-      expect(event["breadcrumbs"]["values"][0]["message"]).to eq("I'm sad!")
-    end
+    event = JSON.parse(Raven.client.transport.events.last[1])
 
-    it "clears context after raising" do
-      process_job("SadWorker")
-      process_job("VerySadWorker")
-
-      event = JSON.parse(Raven.client.transport.events.last[1])
-
-      expect(event["tags"]).to eq("mood" => "very sad")
-      expect(event["breadcrumbs"]["values"][0]["message"]).to eq("I'm very sad!")
-    end
-
-    it "captures exceptions raised during events" do
-      Sidekiq.options[:lifecycle_events][:startup] = [proc { raise "Uhoh!" }]
-      @processor.fire_event(:startup)
-
-      event = JSON.parse(Raven.client.transport.events.last[1])
-
-      expect(event["logentry"]["message"]).to eq "Uhoh!"
-      expect(event["transaction"]).to eq "Sidekiq/startup"
-    end
-
-    it "has some context when capturing, even if no exception raised" do
-      process_job("ReportingWorker")
-
-      event = JSON.parse(Raven.client.transport.events.last[1])
-
-      expect(event["logentry"]["message"]).to eq "I have something to say!"
-      expect(event["extra"]["sidekiq"]).to eq("class" => "ReportingWorker", "queue" => "default")
-    end
+    expect(event["logentry"]["message"]).to eq "I have something to say!"
+    expect(event["extra"]["sidekiq"]).to eq("class" => "ReportingWorker", "queue" => "default")
   end
 end

--- a/spec/raven/json_spec.rb
+++ b/spec/raven/json_spec.rb
@@ -41,24 +41,22 @@ RSpec.describe JSON do
     expect(JSON.parse("[123e090000000]")).to eq [+1.0 / 0.0]
   end
 
-  if RUBY_VERSION.to_f >= 2.0 # 1.9 just hangs on this.
-    it 'it raises the correct error on strings that look like incomplete objects' do
-      expect { JSON.parse("{") }.to raise_error(JSON::ParserError)
-      expect { JSON.parse("[") }.to raise_error(JSON::ParserError)
-    end
+  it 'it raises the correct error on strings that look like incomplete objects' do
+    expect { JSON.parse("{") }.to raise_error(JSON::ParserError)
+    expect { JSON.parse("[") }.to raise_error(JSON::ParserError)
+  end
 
-    it "accepts any encoding which is internally valid" do
-      expect do
-        JSON.parse(%({"example": "this is a utf8 or ASCII string"}))
-      end.not_to raise_error
+  it "accepts any encoding which is internally valid" do
+    expect do
+      JSON.parse(%({"example": "this is a utf8 or ASCII string"}))
+    end.not_to raise_error
 
-      expect do
-        JSON.parse(%({"example": "this is a utf8 or ASCII string"}).encode("utf-16"))
-      end.not_to raise_error
+    expect do
+      JSON.parse(%({"example": "this is a utf8 or ASCII string"}).encode("utf-16"))
+    end.not_to raise_error
 
-      expect do
-        JSON.parse(%({"example": "this is a utf8 or ASCII string"}).encode("US-ASCII"))
-      end.not_to raise_error
-    end
+    expect do
+      JSON.parse(%({"example": "this is a utf8 or ASCII string"}).encode("US-ASCII"))
+    end.not_to raise_error
   end
 end


### PR DESCRIPTION
We require version > 2.3 now, so those checks are redundant.