### PR TITLE
Rubocop upgrade and style fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,16 +19,10 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 11
 
-Metrics/LineLength:
-  Max: 155
-
 Metrics/MethodLength:
   Max: 30
 
 Style/SignalException:
-  Enabled: false
-
-Performance/Casecmp:
   Enabled: false
 
 Style/ClassAndModuleChildren:
@@ -52,11 +46,6 @@ Style/CaseEquality:
 Style/DoubleNegation:
   Enabled: false
 
-Style/FileName:
-  Exclude:
-    - 'lib/sentry-raven-without-integrations.rb'
-    - 'lib/sentry-raven.rb'
-
 Style/NumericLiterals:
   Exclude:
     - 'spec/raven/processors/sanitizedata_processor_spec.rb'
@@ -72,3 +61,14 @@ Lint/RescueException:
     - 'lib/raven/integrations/rack.rb'
     - 'lib/raven/integrations/sidekiq.rb'
     - 'spec/raven/event_spec.rb'
+
+
+Layout/LineLength:
+  Max: 155
+
+Naming/FileName:
+  Exclude:
+    - 'lib/sentry-raven-without-integrations.rb'
+    - 'lib/sentry-raven.rb'
+
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,6 +99,7 @@ Naming/FileName:
   Exclude:
     - 'lib/sentry-raven-without-integrations.rb'
     - 'lib/sentry-raven.rb'
+    - 'lib/raven/integrations/rack-timeout.rb'
 
 Naming/MethodParameterName:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,9 @@ Style/DoubleNegation:
 Style/GuardClause:
   Enabled: false
 
+Style/RedundantBegin:
+  Enabled: false
+
 Style/NumericLiterals:
   Exclude:
     - 'spec/raven/processors/sanitizedata_processor_spec.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Metrics/ClassLength:
 Metrics/AbcSize:
   Max: 40
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/CyclomaticComplexity:
   Max: 12
 
@@ -22,16 +25,31 @@ Metrics/PerceivedComplexity:
 Metrics/MethodLength:
   Max: 30
 
+Style/SymbolArray:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/SignalException:
   Enabled: false
 
 Style/ClassAndModuleChildren:
   Enabled: false
 
+Style/RescueStandardError:
+  Enabled: false
+
 Style/ParallelAssignment:
   Enabled: false
 
 Style/Documentation:
+  Enabled: false
+
+Style/CommentedKeyword:
   Enabled: false
 
 Style/RescueModifier:
@@ -46,12 +64,18 @@ Style/CaseEquality:
 Style/DoubleNegation:
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
 Style/NumericLiterals:
   Exclude:
     - 'spec/raven/processors/sanitizedata_processor_spec.rb'
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
+
+Style/IfUnlessModifier:
+  Enabled: false
 
 Lint/RescueException:
   Exclude:
@@ -62,6 +86,11 @@ Lint/RescueException:
     - 'lib/raven/integrations/sidekiq.rb'
     - 'spec/raven/event_spec.rb'
 
+Lint/SuppressedException:
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false
 
 Layout/LineLength:
   Max: 155
@@ -71,4 +100,6 @@ Naming/FileName:
     - 'lib/sentry-raven-without-integrations.rb'
     - 'lib/sentry-raven.rb'
 
+Naming/MethodParameterName:
+  Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "benchmark-ips"
 gem "benchmark-ipsa"
 gem "ruby-prof", platform: :mri
 gem "rake", "> 12"
-gem "rubocop", "~> 0.41.1" # Last version that supported 1.9, upgrade to 0.50 after we drop 1.9
+gem "rubocop", "~> 0.81.0"
 gem "rspec", "~> 3.9.0"
 gem "capybara", "~> 3.15.0" # rspec system tests
 gem "puma" # rspec system tests

--- a/lib/raven/backtrace.rb
+++ b/lib/raven/backtrace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ## Inspired by Rails' and Airbrake's backtrace parsers.
 
 module Raven
@@ -5,16 +7,16 @@ module Raven
   class Backtrace
     # Handles backtrace parsing line by line
     class Line
-      RB_EXTENSION = ".rb".freeze
+      RB_EXTENSION = ".rb"
       # regexp (optional leading X: on windows, or JRuby9000 class-prefix)
       RUBY_INPUT_FORMAT = /
         ^ \s* (?: [a-zA-Z]: | uri:classloader: )? ([^:]+ | <.*>):
         (\d+)
         (?: :in \s `([^']+)')?$
-      /x
+      /x.freeze
 
       # org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
-      JAVA_INPUT_FORMAT = /^(.+)\.([^\.]+)\(([^\:]+)\:(\d+)\)$/
+      JAVA_INPUT_FORMAT = /^(.+)\.([^\.]+)\(([^\:]+)\:(\d+)\)$/.freeze
 
       # The file portion of the line (such as app/models/user.rb)
       attr_reader :file
@@ -84,7 +86,7 @@ module Raven
       attr_writer :file, :number, :method, :module_name
     end
 
-    APP_DIRS_PATTERN = /(bin|exe|app|config|lib|test)/
+    APP_DIRS_PATTERN = /(bin|exe|app|config|lib|test)/.freeze
 
     # holder for an Array of Backtrace::Line instances
     attr_reader :lines

--- a/lib/raven/backtrace.rb
+++ b/lib/raven/backtrace.rb
@@ -76,7 +76,7 @@ module Raven
 
       def self.in_app_pattern
         @in_app_pattern ||= begin
-          project_root = Raven.configuration.project_root && Raven.configuration.project_root.to_s
+          project_root = Raven.configuration.project_root&.to_s
           Regexp.new("^(#{project_root}/)?#{Raven.configuration.app_dirs_pattern || APP_DIRS_PATTERN}")
         end
       end

--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -91,6 +91,7 @@ module Raven
 
     def safely_prepend(module_name, opts = {})
       return if opts[:to].nil? || opts[:from].nil?
+
       if opts[:to].respond_to?(:prepend, true)
         opts[:to].send(:prepend, opts[:from].const_get(module_name))
       else
@@ -101,6 +102,7 @@ module Raven
     def sys_command(command)
       result = `#{command} 2>&1` rescue nil
       return if result.nil? || result.empty? || ($CHILD_STATUS && $CHILD_STATUS.exitstatus != 0)
+
       result.strip
     end
   end

--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -85,8 +85,8 @@ module Raven
 
     def load_integration(integration)
       require "raven/integrations/#{integration}"
-    rescue Exception => error
-      logger.warn "Unable to load raven/integrations/#{integration}: #{error}"
+    rescue Exception => e
+      logger.warn "Unable to load raven/integrations/#{integration}: #{e}"
     end
 
     def safely_prepend(module_name, opts = {})

--- a/lib/raven/breadcrumbs.rb
+++ b/lib/raven/breadcrumbs.rb
@@ -64,7 +64,7 @@ module Raven
     end
 
     def empty?
-      !members.any?
+      members.none?
     end
 
     def to_hash

--- a/lib/raven/breadcrumbs/activesupport.rb
+++ b/lib/raven/breadcrumbs/activesupport.rb
@@ -1,19 +1,19 @@
 module Raven
   module ActiveSupportBreadcrumbs
     class << self
-        def add(name, started, _finished, _unique_id, data)
-          Raven.breadcrumbs.record do |crumb|
-            crumb.data = data
-            crumb.category = name
-            crumb.timestamp = started.to_i
-          end
+      def add(name, started, _finished, _unique_id, data)
+        Raven.breadcrumbs.record do |crumb|
+          crumb.data = data
+          crumb.category = name
+          crumb.timestamp = started.to_i
         end
+      end
 
-        def inject
-          ActiveSupport::Notifications.subscribe(/.*/) do |name, started, finished, unique_id, data|
-            add(name, started, finished, unique_id, data)
-          end
+      def inject
+        ActiveSupport::Notifications.subscribe(/.*/) do |name, started, finished, unique_id, data|
+          add(name, started, finished, unique_id, data)
         end
+      end
     end
   end
 end

--- a/lib/raven/breadcrumbs/logger.rb
+++ b/lib/raven/breadcrumbs/logger.rb
@@ -10,7 +10,7 @@ module Raven
       ::Logger::FATAL => 'fatal'
     }.freeze
 
-    EXC_FORMAT = /^([a-zA-Z0-9]+)\:\s(.*)$/
+    EXC_FORMAT = /^([a-zA-Z0-9]+)\:\s(.*)$/.freeze
 
     def self.parse_exception(message)
       lines = message.split(/\n\s*/)

--- a/lib/raven/breadcrumbs/logger.rb
+++ b/lib/raven/breadcrumbs/logger.rb
@@ -4,8 +4,8 @@ module Raven
   module BreadcrumbLogger
     LEVELS = {
       ::Logger::DEBUG => 'debug',
-      ::Logger::INFO  => 'info',
-      ::Logger::WARN  => 'warn',
+      ::Logger::INFO => 'info',
+      ::Logger::WARN => 'warn',
       ::Logger::ERROR => 'error',
       ::Logger::FATAL => 'fatal'
     }.freeze

--- a/lib/raven/cli.rb
+++ b/lib/raven/cli.rb
@@ -29,8 +29,8 @@ module Raven
 
       begin
         1 / 0
-      rescue ZeroDivisionError => exception
-        evt = instance.capture_exception(exception)
+      rescue ZeroDivisionError => e
+        evt = instance.capture_exception(e)
       end
 
       if evt && !(evt.is_a? Thread)

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'base64'
 require 'json'
 require 'zlib'
@@ -120,7 +121,9 @@ module Raven
         configuration.logger.warn "Not sending event due to previous failure(s)."
       end
       configuration.logger.warn("Failed to submit event: #{get_log_message(event)}")
-      configuration.transport_failure_callback.call(event) if configuration.transport_failure_callback
+
+      # configuration.transport_failure_callback can be false & nil
+      configuration.transport_failure_callback.call(event) if configuration.transport_failure_callback # rubocop:disable Style/SafeNavigation
     end
   end
 

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -6,9 +6,9 @@ require 'zlib'
 module Raven
   # Encodes events and sends them to the Sentry server.
   class Client
-    PROTOCOL_VERSION = '5'.freeze
-    USER_AGENT = "raven-ruby/#{Raven::VERSION}".freeze
-    CONTENT_TYPE = 'application/json'.freeze
+    PROTOCOL_VERSION = '5'
+    USER_AGENT = "raven-ruby/#{Raven::VERSION}"
+    CONTENT_TYPE = 'application/json'
 
     attr_accessor :configuration
 

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -430,7 +430,7 @@ module Raven
     end
 
     def capture_allowed_by_callback?(message_or_exc)
-      return true if !should_capture || message_or_exc.nil? || should_capture.call(*[message_or_exc])
+      return true if !should_capture || message_or_exc.nil? || should_capture.call(message_or_exc)
 
       @errors << "should_capture returned false"
       false

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -236,6 +236,7 @@ module Raven
 
     def server=(value)
       return if value.nil?
+
       uri = URI.parse(value)
       uri_path = uri.path.split('/')
 
@@ -260,6 +261,7 @@ module Raven
 
     def encoding=(encoding)
       raise(Error, 'Unsupported encoding') unless %w(gzip json).include? encoding
+
       @encoding = encoding
     end
 
@@ -267,6 +269,7 @@ module Raven
       unless value == false || value.respond_to?(:call)
         raise(ArgumentError, "async must be callable (or false to disable)")
       end
+
       @async = value
     end
 
@@ -274,6 +277,7 @@ module Raven
       unless value == false || value.respond_to?(:call)
         raise(ArgumentError, "transport_failure_callback must be callable (or false to disable)")
       end
+
       @transport_failure_callback = value
     end
 
@@ -281,6 +285,7 @@ module Raven
       unless value == false || value.respond_to?(:call)
         raise ArgumentError, "should_capture must be callable (or false to disable)"
       end
+
       @should_capture = value
     end
 
@@ -288,6 +293,7 @@ module Raven
       unless value == false || value.respond_to?(:call)
         raise ArgumentError, "before_send must be callable (or false to disable)"
       end
+
       @before_send = value
     end
 
@@ -418,18 +424,21 @@ module Raven
 
     def capture_in_current_environment?
       return true unless environments.any? && !environments.include?(current_environment)
+
       @errors << "Not configured to send/capture in environment '#{current_environment}'"
       false
     end
 
     def capture_allowed_by_callback?(message_or_exc)
       return true if !should_capture || message_or_exc.nil? || should_capture.call(*[message_or_exc])
+
       @errors << "should_capture returned false"
       false
     end
 
     def valid?
       return true if %w(server host path public_key project_id).all? { |k| public_send(k) }
+
       if server
         %w(server host path public_key project_id).map do |key|
           @errors << "No #{key} specified" unless public_send(key)
@@ -442,6 +451,7 @@ module Raven
 
     def sample_allowed?
       return true if sample_rate == 1.0
+
       if Random::DEFAULT.rand >= sample_rate
         @errors << "Excluded by random sample"
         false

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -351,8 +351,8 @@ module Raven
         detect_release_from_git ||
         detect_release_from_capistrano ||
         detect_release_from_heroku
-    rescue => ex
-      logger.error "Error detecting release: #{ex.message}"
+    rescue => e
+      logger.error "Error detecting release: #{e.message}"
     end
 
     def excluded_exception?(incoming_exception)

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -76,7 +76,7 @@ module Raven
     end
 
     def message
-      @interfaces[:logentry] && @interfaces[:logentry].unformatted_message
+      @interfaces[:logentry]&.unformatted_message
     end
 
     def message=(args)

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'socket'
 require 'securerandom'
 
@@ -96,7 +97,7 @@ module Raven
     end
 
     def level=(new_level) # needed to meet the Sentry spec
-      @level = new_level == "warn" || new_level == :warn ? :warning : new_level
+      @level = new_level.to_s == "warn" ? :warning : new_level
     end
 
     def interface(name, value = nil, &block)

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -102,6 +102,7 @@ module Raven
     def interface(name, value = nil, &block)
       int = Interface.registered[name]
       raise(Error, "Unknown interface: #{name}") unless int
+
       @interfaces[int.sentry_alias] = int.new(value, &block) if value || block
       @interfaces[int.sentry_alias]
     end

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -51,6 +51,7 @@ module Raven
     # Tell the log that the client is good to go
     def report_status
       return if configuration.silence_ready
+
       if configuration.capture_allowed?
         logger.info "Raven #{VERSION} ready to catch errors"
       else

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -118,8 +118,8 @@ module Raven
             # We have to convert to a JSON-like hash, because background job
             # processors (esp ActiveJob) may not like weird types in the event hash
             configuration.async.call(evt.to_json_compatible)
-          rescue => ex
-            logger.error("async event sending failed: #{ex.message}")
+          rescue => e
+            logger.error("async event sending failed: #{e.message}")
             send_event(evt, make_hint(obj))
           end
         else

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -112,7 +112,7 @@ module Raven
       message_or_exc = obj.is_a?(String) ? "message" : "exception"
       options[:configuration] = configuration
       options[:context] = context
-      if (evt = Event.send("from_" + message_or_exc, obj, options))
+      if evt = Event.send("from_" + message_or_exc, obj, options)
         yield evt if block_given?
         if configuration.async?
           begin

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -8,20 +8,20 @@ module Delayed
             # Forward the call to the next callback in the callback chain
           block.call(job, *args)
 
-      rescue Exception => e
+        rescue Exception => e
           # Log error to Sentry
-        extra = {
-          :delayed_job => {
-            :id          => job.id.to_s,
-            :priority    => job.priority,
-            :attempts    => job.attempts,
-            :run_at      => job.run_at,
-            :locked_at   => job.locked_at,
-            :locked_by   => job.locked_by,
-            :queue       => job.queue,
-            :created_at  => job.created_at
+          extra = {
+            :delayed_job => {
+              :id          => job.id.to_s,
+              :priority    => job.priority,
+              :attempts    => job.attempts,
+              :run_at      => job.run_at,
+              :locked_at   => job.locked_at,
+              :locked_by   => job.locked_by,
+              :queue       => job.queue,
+              :created_at  => job.created_at
+            }
           }
-        }
           # last_error can be nil
           extra[:last_error] = job.last_error[0...1000] if job.last_error
           # handlers are YAML objects in strings, we definitely can't
@@ -41,8 +41,8 @@ module Delayed
 
           # Make sure we propagate the failure!
           raise e
-      ensure
-        ::Raven::Context.clear!
+        ensure
+          ::Raven::Context.clear!
           ::Raven::BreadcrumbBuffer.clear!
         end
       end

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -12,14 +12,14 @@ module Delayed
           # Log error to Sentry
           extra = {
             :delayed_job => {
-              :id          => job.id.to_s,
-              :priority    => job.priority,
-              :attempts    => job.attempts,
-              :run_at      => job.run_at,
-              :locked_at   => job.locked_at,
-              :locked_by   => job.locked_by,
-              :queue       => job.queue,
-              :created_at  => job.created_at
+              :id => job.id.to_s,
+              :priority => job.priority,
+              :attempts => job.attempts,
+              :run_at => job.run_at,
+              :locked_at => job.locked_at,
+              :locked_by => job.locked_by,
+              :queue => job.queue,
+              :created_at => job.created_at
             }
           }
           # last_error can be nil
@@ -32,8 +32,8 @@ module Delayed
             extra[:active_job] = job.payload_object.job_data
           end
           ::Raven.capture_exception(e,
-                                    :logger  => 'delayed_job',
-                                    :tags    => {
+                                    :logger => 'delayed_job',
+                                    :tags => {
                                       :delayed_job_queue => job.queue,
                                       :delayed_job_id => job.id.to_s
                                     },

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -5,7 +5,6 @@ module Delayed
     class Raven < ::Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.around(:invoke_job) do |job, *args, &block|
-
             # Forward the call to the next callback in the callback chain
           block.call(job, *args)
 
@@ -45,7 +44,6 @@ module Delayed
       ensure
         ::Raven::Context.clear!
           ::Raven::BreadcrumbBuffer.clear!
-
         end
       end
     end

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -9,7 +9,7 @@ module Delayed
             # Forward the call to the next callback in the callback chain
             block.call(job, *args)
 
-          rescue Exception => exception
+          rescue Exception => e
             # Log error to Sentry
             extra = {
               :delayed_job => {
@@ -32,7 +32,7 @@ module Delayed
             if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
               extra[:active_job] = job.payload_object.job_data
             end
-            ::Raven.capture_exception(exception,
+            ::Raven.capture_exception(e,
                                       :logger  => 'delayed_job',
                                       :tags    => {
                                         :delayed_job_queue => job.queue,
@@ -41,7 +41,7 @@ module Delayed
                                       :extra => extra)
 
             # Make sure we propagate the failure!
-            raise exception
+            raise e
           ensure
             ::Raven::Context.clear!
             ::Raven::BreadcrumbBuffer.clear!

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -5,45 +5,46 @@ module Delayed
     class Raven < ::Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.around(:invoke_job) do |job, *args, &block|
-          # Forward the call to the next callback in the callback chain
-          block.call(job, *args)
-
-        rescue Exception => e
-          # Log error to Sentry
-          extra = {
-            :delayed_job => {
-              :id => job.id.to_s,
-              :priority => job.priority,
-              :attempts => job.attempts,
-              :run_at => job.run_at,
-              :locked_at => job.locked_at,
-              :locked_by => job.locked_by,
-              :queue => job.queue,
-              :created_at => job.created_at
+          begin
+            # Forward the call to the next callback in the callback chain
+            block.call(job, *args)
+          rescue Exception => e
+            # Log error to Sentry
+            extra = {
+              :delayed_job => {
+                :id => job.id.to_s,
+                :priority => job.priority,
+                :attempts => job.attempts,
+                :run_at => job.run_at,
+                :locked_at => job.locked_at,
+                :locked_by => job.locked_by,
+                :queue => job.queue,
+                :created_at => job.created_at
+              }
             }
-          }
-          # last_error can be nil
-          extra[:last_error] = job.last_error[0...1000] if job.last_error
-          # handlers are YAML objects in strings, we definitely can't
-          # report all of that or the event will get truncated randomly
-          extra[:handler] = job.handler[0...1000] if job.handler
+            # last_error can be nil
+            extra[:last_error] = job.last_error[0...1000] if job.last_error
+            # handlers are YAML objects in strings, we definitely can't
+            # report all of that or the event will get truncated randomly
+            extra[:handler] = job.handler[0...1000] if job.handler
 
-          if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
-            extra[:active_job] = job.payload_object.job_data
+            if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
+              extra[:active_job] = job.payload_object.job_data
+            end
+            ::Raven.capture_exception(e,
+                                      :logger => 'delayed_job',
+                                      :tags => {
+                                        :delayed_job_queue => job.queue,
+                                        :delayed_job_id => job.id.to_s
+                                      },
+                                      :extra => extra)
+
+            # Make sure we propagate the failure!
+            raise e
+          ensure
+            ::Raven::Context.clear!
+            ::Raven::BreadcrumbBuffer.clear!
           end
-          ::Raven.capture_exception(e,
-                                    :logger => 'delayed_job',
-                                    :tags => {
-                                      :delayed_job_queue => job.queue,
-                                      :delayed_job_id => job.id.to_s
-                                    },
-                                    :extra => extra)
-
-          # Make sure we propagate the failure!
-          raise e
-        ensure
-          ::Raven::Context.clear!
-          ::Raven::BreadcrumbBuffer.clear!
         end
       end
     end

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -5,7 +5,7 @@ module Delayed
     class Raven < ::Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.around(:invoke_job) do |job, *args, &block|
-          begin
+          
             # Forward the call to the next callback in the callback chain
             block.call(job, *args)
 
@@ -45,7 +45,7 @@ module Delayed
           ensure
             ::Raven::Context.clear!
             ::Raven::BreadcrumbBuffer.clear!
-          end
+          
         end
       end
     end

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -5,7 +5,7 @@ module Delayed
     class Raven < ::Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.around(:invoke_job) do |job, *args, &block|
-          
+
             # Forward the call to the next callback in the callback chain
           block.call(job, *args)
 
@@ -45,7 +45,7 @@ module Delayed
       ensure
         ::Raven::Context.clear!
           ::Raven::BreadcrumbBuffer.clear!
-          
+
         end
       end
     end

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -5,7 +5,7 @@ module Delayed
     class Raven < ::Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.around(:invoke_job) do |job, *args, &block|
-            # Forward the call to the next callback in the callback chain
+          # Forward the call to the next callback in the callback chain
           block.call(job, *args)
 
         rescue Exception => e

--- a/lib/raven/integrations/delayed_job.rb
+++ b/lib/raven/integrations/delayed_job.rb
@@ -7,44 +7,44 @@ module Delayed
         lifecycle.around(:invoke_job) do |job, *args, &block|
           
             # Forward the call to the next callback in the callback chain
-            block.call(job, *args)
+          block.call(job, *args)
 
-          rescue Exception => e
-            # Log error to Sentry
-            extra = {
-              :delayed_job => {
-                :id          => job.id.to_s,
-                :priority    => job.priority,
-                :attempts    => job.attempts,
-                :run_at      => job.run_at,
-                :locked_at   => job.locked_at,
-                :locked_by   => job.locked_by,
-                :queue       => job.queue,
-                :created_at  => job.created_at
-              }
-            }
-            # last_error can be nil
-            extra[:last_error] = job.last_error[0...1000] if job.last_error
-            # handlers are YAML objects in strings, we definitely can't
-            # report all of that or the event will get truncated randomly
-            extra[:handler] = job.handler[0...1000] if job.handler
+      rescue Exception => e
+          # Log error to Sentry
+        extra = {
+          :delayed_job => {
+            :id          => job.id.to_s,
+            :priority    => job.priority,
+            :attempts    => job.attempts,
+            :run_at      => job.run_at,
+            :locked_at   => job.locked_at,
+            :locked_by   => job.locked_by,
+            :queue       => job.queue,
+            :created_at  => job.created_at
+          }
+        }
+          # last_error can be nil
+          extra[:last_error] = job.last_error[0...1000] if job.last_error
+          # handlers are YAML objects in strings, we definitely can't
+          # report all of that or the event will get truncated randomly
+          extra[:handler] = job.handler[0...1000] if job.handler
 
-            if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
-              extra[:active_job] = job.payload_object.job_data
-            end
-            ::Raven.capture_exception(e,
-                                      :logger  => 'delayed_job',
-                                      :tags    => {
-                                        :delayed_job_queue => job.queue,
-                                        :delayed_job_id => job.id.to_s
-                                      },
-                                      :extra => extra)
+          if job.respond_to?('payload_object') && job.payload_object.respond_to?('job_data')
+            extra[:active_job] = job.payload_object.job_data
+          end
+          ::Raven.capture_exception(e,
+                                    :logger  => 'delayed_job',
+                                    :tags    => {
+                                      :delayed_job_queue => job.queue,
+                                      :delayed_job_id => job.id.to_s
+                                    },
+                                    :extra => extra)
 
-            # Make sure we propagate the failure!
-            raise e
-          ensure
-            ::Raven::Context.clear!
-            ::Raven::BreadcrumbBuffer.clear!
+          # Make sure we propagate the failure!
+          raise e
+      ensure
+        ::Raven::Context.clear!
+          ::Raven::BreadcrumbBuffer.clear!
           
         end
       end

--- a/lib/raven/integrations/rack-timeout.rb
+++ b/lib/raven/integrations/rack-timeout.rb
@@ -14,6 +14,5 @@ module RackTimeoutExtensions
   end
 end
 
-# Include is private in Ruby 1.9
-Rack::Timeout::Error.__send__(:include, RackTimeoutExtensions)
-Rack::Timeout::RequestTimeoutException.__send__(:include, RackTimeoutExtensions)
+Rack::Timeout::Error.include(RackTimeoutExtensions)
+Rack::Timeout::RequestTimeoutException.include(RackTimeoutExtensions)

--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -98,7 +98,7 @@ module Raven
 
     def format_headers_for_sentry(env_hash)
       env_hash.each_with_object({}) do |(key, value), memo|
-        
+
         key = key.to_s # rack env can contain symbols
         value = value.to_s
         next unless key.upcase == key # Non-upper case stuff isn't either
@@ -122,7 +122,7 @@ module Raven
         # See: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134
       Raven.logger.warn("Error raised while formatting headers: #{e.message}")
         next
-        
+
       end
     end
 

--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -98,30 +98,32 @@ module Raven
 
     def format_headers_for_sentry(env_hash)
       env_hash.each_with_object({}) do |(key, value), memo|
-        key = key.to_s # rack env can contain symbols
-        value = value.to_s
-        next unless key.upcase == key # Non-upper case stuff isn't either
+        begin
+          key = key.to_s # rack env can contain symbols
+          value = value.to_s
+          next unless key.upcase == key # Non-upper case stuff isn't either
 
-        # Rack adds in an incorrect HTTP_VERSION key, which causes downstream
-        # to think this is a Version header. Instead, this is mapped to
-        # env['SERVER_PROTOCOL']. But we don't want to ignore a valid header
-        # if the request has legitimately sent a Version header themselves.
-        # See: https://github.com/rack/rack/blob/028438f/lib/rack/handler/cgi.rb#L29
-        next if key == 'HTTP_VERSION' && value == env_hash['SERVER_PROTOCOL']
-        next if key == 'HTTP_COOKIE' # Cookies don't go here, they go somewhere else
+          # Rack adds in an incorrect HTTP_VERSION key, which causes downstream
+          # to think this is a Version header. Instead, this is mapped to
+          # env['SERVER_PROTOCOL']. But we don't want to ignore a valid header
+          # if the request has legitimately sent a Version header themselves.
+          # See: https://github.com/rack/rack/blob/028438f/lib/rack/handler/cgi.rb#L29
+          next if key == 'HTTP_VERSION' && value == env_hash['SERVER_PROTOCOL']
+          next if key == 'HTTP_COOKIE' # Cookies don't go here, they go somewhere else
 
-        next unless key.start_with?('HTTP_') || %w(CONTENT_TYPE CONTENT_LENGTH).include?(key)
+          next unless key.start_with?('HTTP_') || %w(CONTENT_TYPE CONTENT_LENGTH).include?(key)
 
-        # Rack stores headers as HTTP_WHAT_EVER, we need What-Ever
-        key = key.sub(/^HTTP_/, "")
-        key = key.split('_').map(&:capitalize).join('-')
-        memo[key] = value
-      rescue StandardError => e
-        # Rails adds objects to the Rack env that can sometimes raise exceptions
-        # when `to_s` is called.
-        # See: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134
-        Raven.logger.warn("Error raised while formatting headers: #{e.message}")
-        next
+          # Rack stores headers as HTTP_WHAT_EVER, we need What-Ever
+          key = key.sub(/^HTTP_/, "")
+          key = key.split('_').map(&:capitalize).join('-')
+          memo[key] = value
+        rescue StandardError => e
+          # Rails adds objects to the Rack env that can sometimes raise exceptions
+          # when `to_s` is called.
+          # See: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134
+          Raven.logger.warn("Error raised while formatting headers: #{e.message}")
+          next
+        end
       end
     end
 

--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -111,6 +111,7 @@ module Raven
         next if key == 'HTTP_COOKIE' # Cookies don't go here, they go somewhere else
 
         next unless key.start_with?('HTTP_') || %w(CONTENT_TYPE CONTENT_LENGTH).include?(key)
+
         # Rack stores headers as HTTP_WHAT_EVER, we need What-Ever
         key = key.sub(/^HTTP_/, "")
         key = key.split('_').map(&:capitalize).join('-')

--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -98,7 +98,6 @@ module Raven
 
     def format_headers_for_sentry(env_hash)
       env_hash.each_with_object({}) do |(key, value), memo|
-
         key = key.to_s # rack env can contain symbols
         value = value.to_s
         next unless key.upcase == key # Non-upper case stuff isn't either
@@ -122,7 +121,6 @@ module Raven
         # See: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134
       Raven.logger.warn("Error raised while formatting headers: #{e.message}")
         next
-
       end
     end
 

--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -116,11 +116,11 @@ module Raven
         key = key.sub(/^HTTP_/, "")
         key = key.split('_').map(&:capitalize).join('-')
         memo[key] = value
-    rescue StandardError => e
+      rescue StandardError => e
         # Rails adds objects to the Rack env that can sometimes raise exceptions
         # when `to_s` is called.
         # See: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134
-      Raven.logger.warn("Error raised while formatting headers: #{e.message}")
+        Raven.logger.warn("Error raised while formatting headers: #{e.message}")
         next
       end
     end

--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -98,7 +98,7 @@ module Raven
 
     def format_headers_for_sentry(env_hash)
       env_hash.each_with_object({}) do |(key, value), memo|
-        begin
+        
           key = key.to_s # rack env can contain symbols
           value = value.to_s
           next unless key.upcase == key # Non-upper case stuff isn't either
@@ -122,7 +122,7 @@ module Raven
           # See: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134
           Raven.logger.warn("Error raised while formatting headers: #{e.message}")
           next
-        end
+        
       end
     end
 

--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -92,8 +92,8 @@ module Raven
         request.body.rewind
         data
       end
-    rescue IOError => ex
-      ex.message
+    rescue IOError => e
+      e.message
     end
 
     def format_headers_for_sentry(env_hash)

--- a/lib/raven/integrations/rack.rb
+++ b/lib/raven/integrations/rack.rb
@@ -99,29 +99,29 @@ module Raven
     def format_headers_for_sentry(env_hash)
       env_hash.each_with_object({}) do |(key, value), memo|
         
-          key = key.to_s # rack env can contain symbols
-          value = value.to_s
-          next unless key.upcase == key # Non-upper case stuff isn't either
+        key = key.to_s # rack env can contain symbols
+        value = value.to_s
+        next unless key.upcase == key # Non-upper case stuff isn't either
 
-          # Rack adds in an incorrect HTTP_VERSION key, which causes downstream
-          # to think this is a Version header. Instead, this is mapped to
-          # env['SERVER_PROTOCOL']. But we don't want to ignore a valid header
-          # if the request has legitimately sent a Version header themselves.
-          # See: https://github.com/rack/rack/blob/028438f/lib/rack/handler/cgi.rb#L29
-          next if key == 'HTTP_VERSION' && value == env_hash['SERVER_PROTOCOL']
-          next if key == 'HTTP_COOKIE' # Cookies don't go here, they go somewhere else
+        # Rack adds in an incorrect HTTP_VERSION key, which causes downstream
+        # to think this is a Version header. Instead, this is mapped to
+        # env['SERVER_PROTOCOL']. But we don't want to ignore a valid header
+        # if the request has legitimately sent a Version header themselves.
+        # See: https://github.com/rack/rack/blob/028438f/lib/rack/handler/cgi.rb#L29
+        next if key == 'HTTP_VERSION' && value == env_hash['SERVER_PROTOCOL']
+        next if key == 'HTTP_COOKIE' # Cookies don't go here, they go somewhere else
 
-          next unless key.start_with?('HTTP_') || %w(CONTENT_TYPE CONTENT_LENGTH).include?(key)
-          # Rack stores headers as HTTP_WHAT_EVER, we need What-Ever
-          key = key.sub(/^HTTP_/, "")
-          key = key.split('_').map(&:capitalize).join('-')
-          memo[key] = value
-        rescue StandardError => e
-          # Rails adds objects to the Rack env that can sometimes raise exceptions
-          # when `to_s` is called.
-          # See: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134
-          Raven.logger.warn("Error raised while formatting headers: #{e.message}")
-          next
+        next unless key.start_with?('HTTP_') || %w(CONTENT_TYPE CONTENT_LENGTH).include?(key)
+        # Rack stores headers as HTTP_WHAT_EVER, we need What-Ever
+        key = key.sub(/^HTTP_/, "")
+        key = key.split('_').map(&:capitalize).join('-')
+        memo[key] = value
+    rescue StandardError => e
+        # Rails adds objects to the Rack env that can sometimes raise exceptions
+        # when `to_s` is called.
+        # See: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/remote_ip.rb#L134
+      Raven.logger.warn("Error raised while formatting headers: #{e.message}")
+        next
         
       end
     end

--- a/lib/raven/integrations/rails/active_job.rb
+++ b/lib/raven/integrations/rails/active_job.rb
@@ -22,6 +22,7 @@ module Raven
         block.call
       rescue Exception => e # rubocop:disable Lint/RescueException
         return if rescue_with_handler(e)
+
         Raven.capture_exception(e, :extra => raven_context(job))
         raise e
       ensure

--- a/lib/raven/integrations/rails/active_job.rb
+++ b/lib/raven/integrations/rails/active_job.rb
@@ -20,10 +20,10 @@ module Raven
 
       def capture_and_reraise_with_sentry(job, block)
         block.call
-      rescue Exception => exception # rubocop:disable Lint/RescueException
-        return if rescue_with_handler(exception)
-        Raven.capture_exception(exception, :extra => raven_context(job))
-        raise exception
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        return if rescue_with_handler(e)
+        Raven.capture_exception(e, :extra => raven_context(job))
+        raise e
       ensure
         Context.clear!
         BreadcrumbBuffer.clear!

--- a/lib/raven/integrations/rails/overrides/debug_exceptions_catcher.rb
+++ b/lib/raven/integrations/rails/overrides/debug_exceptions_catcher.rb
@@ -6,7 +6,7 @@ module Raven
           begin
             env = env_or_request.respond_to?(:env) ? env_or_request.env : env_or_request
             Raven::Rack.capture_exception(exception, env)
-          rescue # rubocop:disable Lint/HandleExceptions
+          rescue
           end
           super
         end
@@ -21,7 +21,7 @@ module Raven
           begin
             env = env_or_request.respond_to?(:env) ? env_or_request.env : env_or_request
             Raven::Rack.capture_exception(exception, env)
-          rescue # rubocop:disable Lint/HandleExceptions
+          rescue
           end
           render_exception_without_raven(env_or_request, exception)
         end

--- a/lib/raven/interface.rb
+++ b/lib/raven/interface.rb
@@ -1,9 +1,9 @@
 module Raven
   class Interface
     def initialize(attributes = nil)
-      attributes.each do |attr, value|
+      attributes&.each do |attr, value|
         public_send "#{attr}=", value
-      end if attributes
+      end
 
       yield self if block_given?
     end

--- a/lib/raven/interfaces/stack_trace.rb
+++ b/lib/raven/interfaces/stack_trace.rb
@@ -58,7 +58,7 @@ module Raven
       end
 
       def project_root
-        @project_root ||= Raven.configuration.project_root && Raven.configuration.project_root.to_s
+        @project_root ||= Raven.configuration.project_root&.to_s
       end
 
       def longest_load_path

--- a/lib/raven/linecache.rb
+++ b/lib/raven/linecache.rb
@@ -10,6 +10,7 @@ module Raven
     # line should be the line requested by lineno. See specs for more information.
     def get_file_context(filename, lineno, context)
       return nil, nil, nil unless valid_path?(filename)
+
       lines = Array.new(2 * context + 1) do |i|
         getline(filename, lineno - context + i)
       end
@@ -33,8 +34,10 @@ module Raven
 
     def getline(path, n)
       return nil if n < 1
+
       lines = getlines(path)
       return nil if lines.nil?
+
       lines[n - 1]
     end
   end

--- a/lib/raven/linecache.rb
+++ b/lib/raven/linecache.rb
@@ -26,8 +26,8 @@ module Raven
     def getlines(path)
       @cache[path] ||= begin
         IO.readlines(path)
-      rescue
-        nil
+                       rescue
+                         nil
       end
     end
 

--- a/lib/raven/logger.rb
+++ b/lib/raven/logger.rb
@@ -3,8 +3,8 @@ require 'logger'
 
 module Raven
   class Logger < ::Logger
-    LOG_PREFIX = "** [Raven] ".freeze
-    PROGNAME   = "sentry".freeze
+    LOG_PREFIX = "** [Raven] "
+    PROGNAME   = "sentry"
 
     def initialize(*)
       super

--- a/lib/raven/logger.rb
+++ b/lib/raven/logger.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'logger'
 
 module Raven

--- a/lib/raven/processor/cookies.rb
+++ b/lib/raven/processor/cookies.rb
@@ -13,6 +13,7 @@ module Raven
       data[:request][:cookies] = STRING_MASK if data[:request][:cookies]
 
       return unless data[:request][:headers] && data[:request][:headers]["Cookie"]
+
       data[:request][:headers]["Cookie"] = STRING_MASK
     end
 
@@ -20,6 +21,7 @@ module Raven
       data["request"]["cookies"] = STRING_MASK if data["request"]["cookies"]
 
       return unless data["request"]["headers"] && data["request"]["headers"]["Cookie"]
+
       data["request"]["headers"]["Cookie"] = STRING_MASK
     end
   end

--- a/lib/raven/processor/post_data.rb
+++ b/lib/raven/processor/post_data.rb
@@ -11,11 +11,13 @@ module Raven
 
     def process_if_symbol_keys(data)
       return unless data[:request][:method] == "POST"
+
       data[:request][:data] = STRING_MASK
     end
 
     def process_if_string_keys(data)
       return unless data["request"]["method"] == "POST"
+
       data["request"]["data"] = STRING_MASK
     end
   end

--- a/lib/raven/processor/removecircularreferences.rb
+++ b/lib/raven/processor/removecircularreferences.rb
@@ -2,6 +2,7 @@ module Raven
   class Processor::RemoveCircularReferences < Processor
     def process(value, visited = [])
       return "(...)" if visited.include?(value.__id__)
+
       visited << value.__id__ if value.is_a?(Array) || value.is_a?(Hash)
 
       case value

--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -4,7 +4,7 @@ require 'json'
 module Raven
   class Processor::SanitizeData < Processor
     DEFAULT_FIELDS = %w(authorization password passwd secret ssn social(.*)?sec).freeze
-    CREDIT_CARD_RE = /\b(?:3[47]\d|(?:4\d|5[1-5]|65)\d{2}|6011)\d{12}\b/
+    CREDIT_CARD_RE = /\b(?:3[47]\d|(?:4\d|5[1-5]|65)\d{2}|6011)\d{12}\b/.freeze
     QUERY_STRING = ['query_string', :query_string].freeze
     JSON_STARTS_WITH = ["[", "{"].freeze
 

--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'json'
 
 module Raven

--- a/lib/raven/processor/sanitizedata.rb
+++ b/lib/raven/processor/sanitizedata.rb
@@ -63,6 +63,7 @@ module Raven
 
     def fields_re
       return @fields_re if instance_variable_defined?(:@fields_re)
+
       fields = DEFAULT_FIELDS | sanitize_fields
       fields -= sanitize_fields_excluded
       @fields_re = /#{fields.map do |f|
@@ -80,6 +81,7 @@ module Raven
 
     def parse_json_or_nil(string)
       return unless string.start_with?(*JSON_STARTS_WITH)
+
       JSON.parse(string)
     rescue JSON::ParserError, NoMethodError
       nil

--- a/lib/raven/processor/utf8conversion.rb
+++ b/lib/raven/processor/utf8conversion.rb
@@ -14,6 +14,7 @@ module Raven
         !value.frozen? ? value.map! { |v| process v } : value.map { |v| process v }
       when Exception
         return value if value.message.valid_encoding?
+
         clean_exc = value.class.new(remove_invalid_bytes(value.message))
         clean_exc.set_backtrace(value.backtrace)
         clean_exc
@@ -27,6 +28,7 @@ module Raven
           value.force_encoding(Encoding::UTF_8)
         end
         return value if value.valid_encoding?
+
         remove_invalid_bytes(value)
       else
         value

--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -26,10 +26,10 @@ module Raven
           req.headers['X-Sentry-Auth'] = auth_header
           req.body = data
         end
-      rescue Faraday::Error => ex
-        error_info = ex.message
-        if ex.response && ex.response[:headers]['x-sentry-error']
-          error_info += " Error in headers is: #{ex.response[:headers]['x-sentry-error']}"
+      rescue Faraday::Error => e
+        error_info = e.message
+        if e.response && e.response[:headers]['x-sentry-error']
+          error_info += " Error in headers is: #{e.response[:headers]['x-sentry-error']}"
         end
         raise Raven::Error, error_info
       end

--- a/lib/raven/transports/http.rb
+++ b/lib/raven/transports/http.rb
@@ -42,7 +42,7 @@ module Raven
         proxy = configuration.public_send(:proxy)
 
         Faraday.new(configuration.server, :ssl => ssl_configuration, :proxy => proxy) do |builder|
-          configuration.faraday_builder.call(builder) if configuration.faraday_builder
+          configuration.faraday_builder&.call(builder)
           builder.response :raise_error
           builder.options.merge! faraday_opts
           builder.headers[:user_agent] = "sentry-ruby/#{Raven::VERSION}"

--- a/lib/raven/utils/exception_cause_chain.rb
+++ b/lib/raven/utils/exception_cause_chain.rb
@@ -7,6 +7,7 @@ module Raven
           while exception.cause
             exception = exception.cause
             break if exceptions.any? { |e| e.object_id == exception.object_id }
+
             exceptions << exception
           end
           exceptions

--- a/lib/raven/utils/real_ip.rb
+++ b/lib/raven/utils/real_ip.rb
@@ -47,8 +47,8 @@ module Raven
           range = IPAddr.new(ip).to_range
           # we want to make sure nobody is sneaking a netmask in
           range.begin == range.end
-      rescue ArgumentError
-        nil
+        rescue ArgumentError
+          nil
         end
       end
 

--- a/lib/raven/utils/real_ip.rb
+++ b/lib/raven/utils/real_ip.rb
@@ -43,12 +43,14 @@ module Raven
         # Split the comma-separated list into an array of strings
         ips = header ? header.strip.split(/[,\s]+/) : []
         ips.select do |ip|
-          # Only return IPs that are valid according to the IPAddr#new method
-          range = IPAddr.new(ip).to_range
-          # we want to make sure nobody is sneaking a netmask in
-          range.begin == range.end
-        rescue ArgumentError
-          nil
+          begin
+            # Only return IPs that are valid according to the IPAddr#new method
+            range = IPAddr.new(ip).to_range
+            # we want to make sure nobody is sneaking a netmask in
+            range.begin == range.end
+          rescue ArgumentError
+            nil
+          end
         end
       end
 

--- a/lib/raven/utils/real_ip.rb
+++ b/lib/raven/utils/real_ip.rb
@@ -43,14 +43,14 @@ module Raven
         # Split the comma-separated list into an array of strings
         ips = header ? header.strip.split(/[,\s]+/) : []
         ips.select do |ip|
-          begin
+          
             # Only return IPs that are valid according to the IPAddr#new method
             range = IPAddr.new(ip).to_range
             # we want to make sure nobody is sneaking a netmask in
             range.begin == range.end
           rescue ArgumentError
             nil
-          end
+          
         end
       end
 

--- a/lib/raven/utils/real_ip.rb
+++ b/lib/raven/utils/real_ip.rb
@@ -43,14 +43,12 @@ module Raven
         # Split the comma-separated list into an array of strings
         ips = header ? header.strip.split(/[,\s]+/) : []
         ips.select do |ip|
-
             # Only return IPs that are valid according to the IPAddr#new method
           range = IPAddr.new(ip).to_range
           # we want to make sure nobody is sneaking a netmask in
           range.begin == range.end
       rescue ArgumentError
         nil
-
         end
       end
 

--- a/lib/raven/utils/real_ip.rb
+++ b/lib/raven/utils/real_ip.rb
@@ -43,14 +43,14 @@ module Raven
         # Split the comma-separated list into an array of strings
         ips = header ? header.strip.split(/[,\s]+/) : []
         ips.select do |ip|
-          
+
             # Only return IPs that are valid according to the IPAddr#new method
           range = IPAddr.new(ip).to_range
           # we want to make sure nobody is sneaking a netmask in
           range.begin == range.end
       rescue ArgumentError
         nil
-          
+
         end
       end
 

--- a/lib/raven/utils/real_ip.rb
+++ b/lib/raven/utils/real_ip.rb
@@ -13,7 +13,7 @@ module Raven
         "fc00::/7",       # private IPv6 range fc00::/7
         "10.0.0.0/8",     # private IPv4 range 10.x.x.x
         "172.16.0.0/12",  # private IPv4 range 172.16.0.0 .. 172.31.255.255
-        "192.168.0.0/16", # private IPv4 range 192.168.x.x
+        "192.168.0.0/16" # private IPv4 range 192.168.x.x
       ].map { |proxy| IPAddr.new(proxy) }
 
       attr_accessor :ip, :ip_addresses
@@ -43,7 +43,7 @@ module Raven
         # Split the comma-separated list into an array of strings
         ips = header ? header.strip.split(/[,\s]+/) : []
         ips.select do |ip|
-            # Only return IPs that are valid according to the IPAddr#new method
+          # Only return IPs that are valid according to the IPAddr#new method
           range = IPAddr.new(ip).to_range
           # we want to make sure nobody is sneaking a netmask in
           range.begin == range.end

--- a/lib/raven/utils/real_ip.rb
+++ b/lib/raven/utils/real_ip.rb
@@ -45,11 +45,11 @@ module Raven
         ips.select do |ip|
           
             # Only return IPs that are valid according to the IPAddr#new method
-            range = IPAddr.new(ip).to_range
-            # we want to make sure nobody is sneaking a netmask in
-            range.begin == range.end
-          rescue ArgumentError
-            nil
+          range = IPAddr.new(ip).to_range
+          # we want to make sure nobody is sneaking a netmask in
+          range.begin == range.end
+      rescue ArgumentError
+        nil
           
         end
       end

--- a/lib/raven/version.rb
+++ b/lib/raven/version.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 module Raven
-  # Freezing this constant breaks in 1.9.x
-  VERSION = "3.0.0" # rubocop:disable Style/MutableConstant
+  VERSION = "3.0.0"
 end

--- a/lib/raven/version.rb
+++ b/lib/raven/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Raven
   VERSION = "3.0.0"
 end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -210,23 +210,27 @@ RSpec.describe Raven::Configuration do
 
       context "when it's on heroku ci" do
         it "returns nil" do
-          original_ci_val = ENV["CI"]
-          ENV["CI"] = "true"
+          begin
+            original_ci_val = ENV["CI"]
+            ENV["CI"] = "true"
 
-          expect(subject.release).to eq(nil)
-        ensure
-          ENV["CI"] = original_ci_val
+            expect(subject.release).to eq(nil)
+          ensure
+            ENV["CI"] = original_ci_val
+          end
         end
       end
 
       context "when it's not on heroku ci" do
         around do |example|
-          original_ci_val = ENV["CI"]
-          ENV["CI"] = nil
+          begin
+            original_ci_val = ENV["CI"]
+            ENV["CI"] = nil
 
-          example.run
-        ensure
-          ENV["CI"] = original_ci_val
+            example.run
+          ensure
+            ENV["CI"] = original_ci_val
+          end
         end
 
         it "returns nil + logs an warning if HEROKU_SLUG_COMMIT is not set" do
@@ -238,11 +242,13 @@ RSpec.describe Raven::Configuration do
         end
 
         it "returns HEROKU_SLUG_COMMIT" do
-          ENV["HEROKU_SLUG_COMMIT"] = "REVISION"
+          begin
+            ENV["HEROKU_SLUG_COMMIT"] = "REVISION"
 
-          expect(subject.release).to eq("REVISION")
-        ensure
-          ENV["HEROKU_SLUG_COMMIT"] = nil
+            expect(subject.release).to eq("REVISION")
+          ensure
+            ENV["HEROKU_SLUG_COMMIT"] = nil
+          end
         end
       end
     end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -214,8 +214,8 @@ RSpec.describe Raven::Configuration do
           ENV["CI"] = "true"
 
           expect(subject.release).to eq(nil)
-      ensure
-        ENV["CI"] = original_ci_val
+        ensure
+          ENV["CI"] = original_ci_val
         end
       end
 
@@ -225,8 +225,8 @@ RSpec.describe Raven::Configuration do
           ENV["CI"] = nil
 
           example.run
-      ensure
-        ENV["CI"] = original_ci_val
+        ensure
+          ENV["CI"] = original_ci_val
         end
 
         it "returns nil + logs an warning if HEROKU_SLUG_COMMIT is not set" do
@@ -241,8 +241,8 @@ RSpec.describe Raven::Configuration do
           ENV["HEROKU_SLUG_COMMIT"] = "REVISION"
 
           expect(subject.release).to eq("REVISION")
-      ensure
-        ENV["HEROKU_SLUG_COMMIT"] = nil
+        ensure
+          ENV["HEROKU_SLUG_COMMIT"] = nil
         end
       end
     end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -210,27 +210,23 @@ RSpec.describe Raven::Configuration do
 
       context "when it's on heroku ci" do
         it "returns nil" do
-
           original_ci_val = ENV["CI"]
           ENV["CI"] = "true"
 
           expect(subject.release).to eq(nil)
       ensure
         ENV["CI"] = original_ci_val
-
         end
       end
 
       context "when it's not on heroku ci" do
         around do |example|
-
           original_ci_val = ENV["CI"]
           ENV["CI"] = nil
 
           example.run
       ensure
         ENV["CI"] = original_ci_val
-
         end
 
         it "returns nil + logs an warning if HEROKU_SLUG_COMMIT is not set" do
@@ -242,13 +238,11 @@ RSpec.describe Raven::Configuration do
         end
 
         it "returns HEROKU_SLUG_COMMIT" do
-
           ENV["HEROKU_SLUG_COMMIT"] = "REVISION"
 
           expect(subject.release).to eq("REVISION")
       ensure
         ENV["HEROKU_SLUG_COMMIT"] = nil
-
         end
       end
     end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -210,27 +210,27 @@ RSpec.describe Raven::Configuration do
 
       context "when it's on heroku ci" do
         it "returns nil" do
-          begin
+          
             original_ci_val = ENV["CI"]
             ENV["CI"] = "true"
 
             expect(subject.release).to eq(nil)
           ensure
             ENV["CI"] = original_ci_val
-          end
+          
         end
       end
 
       context "when it's not on heroku ci" do
         around do |example|
-          begin
+          
             original_ci_val = ENV["CI"]
             ENV["CI"] = nil
 
             example.run
           ensure
             ENV["CI"] = original_ci_val
-          end
+          
         end
 
         it "returns nil + logs an warning if HEROKU_SLUG_COMMIT is not set" do
@@ -242,13 +242,13 @@ RSpec.describe Raven::Configuration do
         end
 
         it "returns HEROKU_SLUG_COMMIT" do
-          begin
+          
             ENV["HEROKU_SLUG_COMMIT"] = "REVISION"
 
             expect(subject.release).to eq("REVISION")
           ensure
             ENV["HEROKU_SLUG_COMMIT"] = nil
-          end
+          
         end
       end
     end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -211,12 +211,12 @@ RSpec.describe Raven::Configuration do
       context "when it's on heroku ci" do
         it "returns nil" do
           
-            original_ci_val = ENV["CI"]
-            ENV["CI"] = "true"
+          original_ci_val = ENV["CI"]
+          ENV["CI"] = "true"
 
-            expect(subject.release).to eq(nil)
-          ensure
-            ENV["CI"] = original_ci_val
+          expect(subject.release).to eq(nil)
+      ensure
+        ENV["CI"] = original_ci_val
           
         end
       end
@@ -224,12 +224,12 @@ RSpec.describe Raven::Configuration do
       context "when it's not on heroku ci" do
         around do |example|
           
-            original_ci_val = ENV["CI"]
-            ENV["CI"] = nil
+          original_ci_val = ENV["CI"]
+          ENV["CI"] = nil
 
-            example.run
-          ensure
-            ENV["CI"] = original_ci_val
+          example.run
+      ensure
+        ENV["CI"] = original_ci_val
           
         end
 
@@ -243,11 +243,11 @@ RSpec.describe Raven::Configuration do
 
         it "returns HEROKU_SLUG_COMMIT" do
           
-            ENV["HEROKU_SLUG_COMMIT"] = "REVISION"
+          ENV["HEROKU_SLUG_COMMIT"] = "REVISION"
 
-            expect(subject.release).to eq("REVISION")
-          ensure
-            ENV["HEROKU_SLUG_COMMIT"] = nil
+          expect(subject.release).to eq("REVISION")
+      ensure
+        ENV["HEROKU_SLUG_COMMIT"] = nil
           
         end
       end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -210,27 +210,27 @@ RSpec.describe Raven::Configuration do
 
       context "when it's on heroku ci" do
         it "returns nil" do
-          
+
           original_ci_val = ENV["CI"]
           ENV["CI"] = "true"
 
           expect(subject.release).to eq(nil)
       ensure
         ENV["CI"] = original_ci_val
-          
+
         end
       end
 
       context "when it's not on heroku ci" do
         around do |example|
-          
+
           original_ci_val = ENV["CI"]
           ENV["CI"] = nil
 
           example.run
       ensure
         ENV["CI"] = original_ci_val
-          
+
         end
 
         it "returns nil + logs an warning if HEROKU_SLUG_COMMIT is not set" do
@@ -242,13 +242,13 @@ RSpec.describe Raven::Configuration do
         end
 
         it "returns HEROKU_SLUG_COMMIT" do
-          
+
           ENV["HEROKU_SLUG_COMMIT"] = "REVISION"
 
           expect(subject.release).to eq("REVISION")
       ensure
         ENV["HEROKU_SLUG_COMMIT"] = nil
-          
+
         end
       end
     end

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -621,9 +621,9 @@ RSpec.describe Raven::Event do
       context 'when running under jRuby' do
         let(:exception) do
           
-            raise java.lang.OutOfMemoryError, "A Java error"
-          rescue Exception => e
-            return e
+          raise java.lang.OutOfMemoryError, "A Java error"
+      rescue Exception => e
+        return e
           
         end
 

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -620,9 +620,11 @@ RSpec.describe Raven::Event do
     if RUBY_PLATFORM == "java"
       context 'when running under jRuby' do
         let(:exception) do
-          raise java.lang.OutOfMemoryError, "A Java error"
-        rescue Exception => e
-          return e
+          begin
+            raise java.lang.OutOfMemoryError, "A Java error"
+          rescue Exception => e
+            return e
+          end
         end
 
         it 'should have a backtrace' do

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -620,11 +620,9 @@ RSpec.describe Raven::Event do
     if RUBY_PLATFORM == "java"
       context 'when running under jRuby' do
         let(:exception) do
-
           raise java.lang.OutOfMemoryError, "A Java error"
       rescue Exception => e
         return e
-
         end
 
         it 'should have a backtrace' do

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -620,11 +620,11 @@ RSpec.describe Raven::Event do
     if RUBY_PLATFORM == "java"
       context 'when running under jRuby' do
         let(:exception) do
-          
+
           raise java.lang.OutOfMemoryError, "A Java error"
       rescue Exception => e
         return e
-          
+
         end
 
         it 'should have a backtrace' do

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -620,11 +620,11 @@ RSpec.describe Raven::Event do
     if RUBY_PLATFORM == "java"
       context 'when running under jRuby' do
         let(:exception) do
-          begin
+          
             raise java.lang.OutOfMemoryError, "A Java error"
           rescue Exception => e
             return e
-          end
+          
         end
 
         it 'should have a backtrace' do

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -621,8 +621,8 @@ RSpec.describe Raven::Event do
       context 'when running under jRuby' do
         let(:exception) do
           raise java.lang.OutOfMemoryError, "A Java error"
-      rescue Exception => e
-        return e
+        rescue Exception => e
+          return e
         end
 
         it 'should have a backtrace' do

--- a/spec/raven/integrations/rails/activejob_spec.rb
+++ b/spec/raven/integrations/rails/activejob_spec.rb
@@ -15,8 +15,7 @@ if defined? ActiveJob
   class RescuedActiveJob < MyActiveJob
     rescue_from TestError, :with => :rescue_callback
 
-    def rescue_callback(error)
-    end
+    def rescue_callback(error); end
   end
 end
 

--- a/spec/raven/integrations/sidekiq_spec.rb
+++ b/spec/raven/integrations/sidekiq_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe "Sidekiq full-stack integration" do
     @processor.instance_variable_set(:'@job', job)
 
     @processor.send(:process, job)
-  rescue # rubocop:disable Lint/HandleExceptions
+  rescue StandardError
     # do nothing
   end
 

--- a/spec/raven/processors/cookies_spec.rb
+++ b/spec/raven/processors/cookies_spec.rb
@@ -1,5 +1,3 @@
-# Encoding: utf-8
-
 require 'spec_helper'
 
 RSpec.describe Raven::Processor::Cookies do

--- a/spec/raven/processors/post_data_spec.rb
+++ b/spec/raven/processors/post_data_spec.rb
@@ -1,5 +1,3 @@
-# Encoding: utf-8
-
 require 'spec_helper'
 
 RSpec.describe Raven::Processor::PostData do

--- a/spec/raven/processors/removecirculareferences_spec.rb
+++ b/spec/raven/processors/removecirculareferences_spec.rb
@@ -1,5 +1,3 @@
-# Encoding: utf-8
-
 require 'spec_helper'
 
 RSpec.describe Raven::Processor::RemoveCircularReferences do

--- a/spec/raven/processors/utf8conversion_spec.rb
+++ b/spec/raven/processors/utf8conversion_spec.rb
@@ -1,5 +1,3 @@
-# Encoding: utf-8
-
 require 'spec_helper'
 
 RSpec.describe Raven::Processor::UTF8Conversion do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,8 +48,8 @@ end
 
 def build_exception
   1 / 0
-rescue ZeroDivisionError => exception
-  return exception
+rescue ZeroDivisionError => e
+  return e
 end
 
 def build_exception_with_cause(cause = "exception a")
@@ -58,8 +58,8 @@ def build_exception_with_cause(cause = "exception a")
   rescue
     raise "exception b"
   end
-rescue RuntimeError => exception
-  return exception
+rescue RuntimeError => e
+  return e
 end
 
 def build_exception_with_two_causes
@@ -72,8 +72,8 @@ def build_exception_with_two_causes
   rescue
     raise "exception c"
   end
-rescue RuntimeError => exception
-  return exception
+rescue RuntimeError => e
+  return e
 end
 
 def build_exception_with_recursive_cause

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,7 @@ end
 def build_exception
   1 / 0
 rescue ZeroDivisionError => e
-  return e
+  e
 end
 
 def build_exception_with_cause(cause = "exception a")
@@ -59,7 +59,7 @@ def build_exception_with_cause(cause = "exception a")
     raise "exception b"
   end
 rescue RuntimeError => e
-  return e
+  e
 end
 
 def build_exception_with_two_causes
@@ -73,7 +73,7 @@ def build_exception_with_two_causes
     raise "exception c"
   end
 rescue RuntimeError => e
-  return e
+  e
 end
 
 def build_exception_with_recursive_cause


### PR DESCRIPTION
- `0.81` is the latest rubocop version that still supports Ruby 2.3.
- some cops, like `Lint/AssignmentInCondition`, require changes that may affect the program. I've disabled all of them right now because part of the library (like `breakcrumbs/logger.rb`) are not covered by tests yet.