### PR TITLE
Fix frozen string issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ matrix:
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M" RAILS_VERSION=4
     - rvm: jruby-9.2.11.1
       env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M" RAILS_VERSION=5
+    - rvm: 2.7
+      env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
     - rvm: ruby-head
       env: RAILS_VERSION=0
   exclude:

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -253,8 +253,8 @@ module Raven
 
       # For anyone who wants to read the base server string
       @server = "#{scheme}://#{host}"
-      @server << ":#{port}" unless port == { 'http' => 80, 'https' => 443 }[scheme]
-      @server << path
+      @server += ":#{port}" unless port == { 'http' => 80, 'https' => 443 }[scheme]
+      @server += path
     end
     alias dsn= server=
 

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe Raven::Event do
         data['ary2'] = data['ary']
 
         Raven::Event.new(:extra => {
-                           :invalid => "invalid\255".force_encoding('UTF-8'),
+                           :invalid => "invalid\255".dup.force_encoding('UTF-8'),
                            :circular => data
                          })
       end

--- a/spec/raven/processors/utf8conversion_spec.rb
+++ b/spec/raven/processors/utf8conversion_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Raven::Processor::UTF8Conversion do
   before do
     @client = double("client")
     @processor = Raven::Processor::UTF8Conversion.new(@client)
-    @bad_utf8_string = "invalid utf8 string goes here\255".force_encoding('UTF-8')
+    @bad_utf8_string = "invalid utf8 string goes here\255".dup.force_encoding('UTF-8')
   end
 
   it "has a utf8 fixture which is not valid utf-8" do
@@ -31,7 +31,7 @@ RSpec.describe Raven::Processor::UTF8Conversion do
 
   it 'should keep valid UTF-8 bytes after cleaning' do
     data = {}
-    data['invalid'] = "한국, 中國, 日本(にっぽん)\255".force_encoding('UTF-8')
+    data['invalid'] = "한국, 中國, 日本(にっぽん)\255".dup.force_encoding('UTF-8')
 
     results = @processor.process(data)
     expect(results['invalid']).to eq("한국, 中國, 日本(にっぽん)")
@@ -61,7 +61,7 @@ RSpec.describe Raven::Processor::UTF8Conversion do
   end
 
   it "deals with unicode hidden in ASCII_8BIT" do
-    data = ["\xE2\x9C\x89 Hello".force_encoding(Encoding::ASCII_8BIT)]
+    data = ["\xE2\x9C\x89 Hello".dup.force_encoding(Encoding::ASCII_8BIT)]
 
     results = @processor.process(data)
 
@@ -72,7 +72,7 @@ RSpec.describe Raven::Processor::UTF8Conversion do
   end
 
   it "deals with unicode hidden in ASCII_8BIT when the string is frozen" do
-    data = ["\xE2\x9C\x89 Hello".force_encoding(Encoding::ASCII_8BIT).freeze]
+    data = ["\xE2\x9C\x89 Hello".dup.force_encoding(Encoding::ASCII_8BIT).freeze]
 
     results = @processor.process(data)
 


### PR DESCRIPTION
This PR:
- Adds a test suite for Ruby option `--enable-frozen-string-literal`
- Fixes #967
- Make tests runnable under `--enable-frozen-string-literal` option