### PR TITLE
Use version-insensitive Sidekiq interface in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,8 @@ rvm:
   - 2.7
 
 env:
-  - RAILS_VERSION=4 SIDEKIQ_VERSION=5
-  - RAILS_VERSION=4 SIDEKIQ_VERSION=6
-  - RAILS_VERSION=5 SIDEKIQ_VERSION=5
-  - RAILS_VERSION=5 SIDEKIQ_VERSION=6
+  - RAILS_VERSION=4
+  - RAILS_VERSION=5
   - RAILS_VERSION=0
 
 addons:
@@ -43,16 +41,6 @@ matrix:
       env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
     - rvm: ruby-head
       env: RAILS_VERSION=0
-  exclude:
-    # sidekiq 6 requires Ruby 2.5
-    - rvm: 2.3
-      env: RAILS_VERSION=4 SIDEKIQ_VERSION=6
-    - rvm: 2.3
-      env: RAILS_VERSION=5 SIDEKIQ_VERSION=6
-    - rvm: 2.4
-      env: RAILS_VERSION=4 SIDEKIQ_VERSION=6
-    - rvm: 2.4
-      env: RAILS_VERSION=5 SIDEKIQ_VERSION=6
 
   allow_failures:
     - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -15,11 +15,7 @@ end
 gem "rack"
 gem "rack-timeout"
 
-if ENV["SIDEKIQ_VERSION"].to_i >= 6 && RUBY_VERSION > '2.5'
-  gem "sidekiq", ">= 6"
-else
-  gem "sidekiq", "< 6"
-end
+gem "sidekiq"
 
 gem "pry"
 gem "benchmark-ips"

--- a/spec/raven/integrations/sidekiq_spec.rb
+++ b/spec/raven/integrations/sidekiq_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 require 'raven/integrations/sidekiq'
-require 'sidekiq/processor'
+require 'sidekiq/manager'
 
 RSpec.describe "Raven::SidekiqErrorHandler" do
   let(:context) do
@@ -122,15 +122,9 @@ RSpec.describe "Sidekiq full-stack integration" do
   end
 
   before do
-    @mgr = double('manager', :options => {})
-    allow(@mgr).to receive(:options).and_return(:queues => ['default'])
-
-    @processor =
-      if Sidekiq::VERSION.to_i >= 6
-        ::Sidekiq::Processor.new(@mgr, @mgr.options)
-      else
-        ::Sidekiq::Processor.new(@mgr)
-      end
+    opts = { :queues => ['default'] }
+    manager = Sidekiq::Manager.new(opts)
+    @processor = manager.workers.first
   end
 
   def process_job(klass)


### PR DESCRIPTION
So we can remove the ugly `SIDEKIQ_VERSION` hack.