### PR TITLE
Speed up jruby CI test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,10 @@ addons:
 
 before_install:
   - service haveged start
-  # Pin bundler version due to https://github.com/rubygems/rubygems/issues/2055
-  - gem install bundler -v 1.16.0
+  # Ruby 2.7 adds default bundler with 2.0+ version
+  # This script removes the default bundler so we can install the version we want
+  - ./cleanup_bundler
+  - gem install bundler -v '1.17'
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ matrix:
       env: RUBYOPT="--enable-frozen-string-literal --debug=frozen-string-literal"
     - rvm: ruby-head
       env: RAILS_VERSION=0
+  exclude:
+    - rvm: 2.7
+      env: RAILS_VERSION=4
 
   allow_failures:
     - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -3,19 +3,19 @@ source "https://rubygems.org/"
 gemspec
 
 if ENV["RAILS_VERSION"] && (ENV["RAILS_VERSION"].to_i == 4)
-  gem "rails", "< 5"
-  gem "rspec-rails", "> 3"
+  gem "rails", "~> 4.2"
+  gem "rspec-rails", "~> 4.0"
 elsif ENV["RAILS_VERSION"] && (ENV["RAILS_VERSION"].to_i == 0)
   # no-op. No Rails.
 else
-  gem "rails", "< 6"
-  gem "rspec-rails", "> 3"
+  gem "rails", "~> 5.2"
+  gem "rspec-rails", "~> 4.0"
 end
+
+gem "sidekiq"
 
 gem "rack"
 gem "rack-timeout"
-
-gem "sidekiq"
 
 gem "pry"
 gem "benchmark-ips"
@@ -23,8 +23,8 @@ gem "benchmark-ipsa"
 gem "ruby-prof", platform: :mri
 gem "rake", "> 12"
 gem "rubocop", "~> 0.41.1" # Last version that supported 1.9, upgrade to 0.50 after we drop 1.9
-gem "rspec", "> 3"
-gem "capybara" # rspec system tests
+gem "rspec", "~> 3.9.0"
+gem "capybara", "~> 3.15.0" # rspec system tests
 gem "puma" # rspec system tests
 
 gem "timecop"

--- a/cleanup_bundler
+++ b/cleanup_bundler
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+gempaths = `gem env gempath`.split(":")
+
+gempaths.each do |gempath|
+  # lookup bundler-*.gemspec files and delete them
+  # this is the only way to completely cleanup default bundler
+  # Note: the bundler gemspecs' paths are different for CRuby and JRuby
+  Dir.glob(gempath.strip + "/specifications/**/bundler-*.gemspec").each { |p| File.delete(p) }
+end


### PR DESCRIPTION
This closes #976 

The JRuby test suite's `bundle install` now only takes 20 seconds and the entire suite takes < 4 minutes.