### PR TITLE
Masking cookies as key/pair instead of a single string

### DIFF
--- a/lib/raven/processor/cookies.rb
+++ b/lib/raven/processor/cookies.rb
@@ -10,19 +10,27 @@ module Raven
     private
 
     def process_if_symbol_keys(data)
-      data[:request][:cookies] = STRING_MASK if data[:request][:cookies]
+      if cookies = data.dig(:request, :cookies)
+        data[:request][:cookies] = generate_masked_cookies(cookies)
+      end
 
-      return unless data[:request][:headers] && data[:request][:headers]["Cookie"]
-
-      data[:request][:headers]["Cookie"] = STRING_MASK
+      if cookies_header = data[:request][:headers]["Cookie"]
+        data[:request][:headers]["Cookie"] = generate_masked_cookies(cookies_header)
+      end
     end
 
     def process_if_string_keys(data)
-      data["request"]["cookies"] = STRING_MASK if data["request"]["cookies"]
+      if cookies = data.dig("request", "cookies")
+        data["request"]["cookies"] = generate_masked_cookies(cookies)
+      end
 
-      return unless data["request"]["headers"] && data["request"]["headers"]["Cookie"]
+      if cookies_header = data.dig("request", "headers", "Cookie")
+        data["request"]["headers"]["Cookie"] = generate_masked_cookies(cookies_header)
+      end
+    end
 
-      data["request"]["headers"]["Cookie"] = STRING_MASK
+    def generate_masked_cookies(cookies)
+      cookies.merge(cookies) { STRING_MASK }
     end
   end
 end

--- a/spec/raven/processors/cookies_spec.rb
+++ b/spec/raven/processors/cookies_spec.rb
@@ -10,18 +10,18 @@ RSpec.describe Raven::Processor::Cookies do
     test_data = {
       :request => {
         :headers => {
-          "Cookie" => "_sentry-testapp_session=SlRKVnNha2Z",
+          "Cookie" => { "_sentry-testapp_session" => "SlRKVnNha2Z" },
           "AnotherHeader" => "still_here"
         },
-        :cookies => "_sentry-testapp_session=SlRKVnNha2Z",
+        :cookies => { "_sentry-testapp_session" => "SlRKVnNha2Z" },
         :some_other_data => "still_here"
       }
     }
 
     result = @processor.process(test_data)
 
-    expect(result[:request][:cookies]).to eq("********")
-    expect(result[:request][:headers]["Cookie"]).to eq("********")
+    expect(result[:request][:cookies]).to eq({ "_sentry-testapp_session" => "********" })
+    expect(result[:request][:headers]["Cookie"]).to eq({ "_sentry-testapp_session" => "********" })
     expect(result[:request][:some_other_data]).to eq("still_here")
     expect(result[:request][:headers]["AnotherHeader"]).to eq("still_here")
   end
@@ -30,18 +30,18 @@ RSpec.describe Raven::Processor::Cookies do
     test_data = {
       "request" => {
         "headers" => {
-          "Cookie" => "_sentry-testapp_session=SlRKVnNha2Z",
+          "Cookie" => { "_sentry-testapp_session" => "SlRKVnNha2Z" },
           "AnotherHeader" => "still_here"
         },
-        "cookies" => "_sentry-testapp_session=SlRKVnNha2Z",
+        "cookies" => { "_sentry-testapp_session" => "SlRKVnNha2Z" },
         "some_other_data" => "still_here"
       }
     }
 
     result = @processor.process(test_data)
 
-    expect(result["request"]["cookies"]).to eq("********")
-    expect(result["request"]["headers"]["Cookie"]).to eq("********")
+    expect(result["request"]["cookies"]).to eq({ "_sentry-testapp_session" => "********" })
+    expect(result["request"]["headers"]["Cookie"]).to eq({ "_sentry-testapp_session" => "********" })
     expect(result["request"]["some_other_data"]).to eq("still_here")
     expect(result["request"]["headers"]["AnotherHeader"]).to eq("still_here")
   end


### PR DESCRIPTION
This closes #900 and #904 