### PR TITLE
Add memory comparison job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "rack-timeout"
 gem "pry"
 gem "benchmark-ips"
 gem "benchmark-ipsa"
+gem "benchmark-memory"
 gem "ruby-prof", platform: :mri
 gem "rake", "> 12"
 gem "rubocop", "~> 0.81.0"

--- a/benchmarks/allocation_comparison.rb
+++ b/benchmarks/allocation_comparison.rb
@@ -1,0 +1,33 @@
+require "benchmark/memory"
+require 'raven'
+require 'raven/breadcrumbs/logger'
+require_relative "../spec/support/test_rails_app/app"
+
+TestApp.configure do |config|
+  config.middleware.delete ActionDispatch::DebugExceptions
+  config.middleware.delete ActionDispatch::ShowExceptions
+end
+
+Raven.configure do |config|
+  config.logger = Logger.new(nil)
+  config.dsn = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
+end
+
+TestApp.initialize!
+@app = Rack::MockRequest.new(TestApp)
+RAILS_EXC = begin
+  @app.get("/exception")
+rescue => exc
+  exc
+end
+
+Raven.capture_exception(RAILS_EXC) # fire it once to get one-time stuff out of rpt
+
+Benchmark.memory do |x|
+  x.report("master")  { Raven.capture_exception(RAILS_EXC) }
+  x.report("branch") { Raven.capture_exception(RAILS_EXC) }
+
+  x.compare!
+  x.hold!("allocation_comparison.json")
+end
+


### PR DESCRIPTION
As a SDK that runs on the production environment, we need to be aware of the performance impact on every PR. So this PR adds a script that can help us comparing memory allocation between 2 branches. I will the corresponding job config in another PR.