### PR TITLE
Add compare_allocation job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
   compare_allocation:
     name: Compare memory allocation with ${{ matrix.ruby_version }} and rails ${{ matrix.rails_version }}
     runs-on: ${{ matrix.os }}
+    needs: test
+    env:
+      RAILS_VERSION: ${{ matrix.rails_version }}
     strategy:
       matrix:
         rails_version: [5.2, 6.0]
@@ -71,19 +74,17 @@ jobs:
         ref: master
 
     - name: Build and run allocation report on master
-      env:
-        RAILS_VERSION: ${{ matrix.rails_version }}
       run: |
         bundle install --jobs 4 --retry 3
         bundle exec ruby benchmarks/allocation_comparison.rb
 
     - uses: actions/checkout@v1
 
-    - name: Build and run allocation report on the branch 
-      env:
-        RAILS_VERSION: ${{ matrix.rails_version }}
+    - name: Rebuild on the branch
       run: |
         bundle install --jobs 4 --retry 3
+    - name: Run allocation report on the branch 
+      run: |
         bundle exec ruby benchmarks/allocation_comparison.rb
 
   job_zeus:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,41 @@ jobs:
         bundle install --jobs 4 --retry 3
         bundle exec rake
 
+  compare_allocation:
+    name: Compare memory allocation with ${{ matrix.ruby_version }} and rails ${{ matrix.rails_version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        rails_version: [5.2, 6.0]
+        ruby_version: [2.6, 2.7]
+        os: [ubuntu-latest]
+    steps:
+    - name: Set up Ruby ${{ matrix.ruby_version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler: 1
+        ruby-version: ${{ matrix.ruby_version }}
+
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+
+    - name: Build and run allocation report on master
+      env:
+        RAILS_VERSION: ${{ matrix.rails_version }}
+      run: |
+        bundle install --jobs 4 --retry 3
+        bundle exec ruby benchmarks/allocation_comparison.rb
+
+    - uses: actions/checkout@v1
+
+    - name: Build and run allocation report on the branch 
+      env:
+        RAILS_VERSION: ${{ matrix.rails_version }}
+      run: |
+        bundle install --jobs 4 --retry 3
+        bundle exec ruby benchmarks/allocation_comparison.rb
+
   job_zeus:
     name: Zeus
     runs-on: ubuntu-latest

--- a/benchmarks/allocation_comparison.rb
+++ b/benchmarks/allocation_comparison.rb
@@ -28,6 +28,6 @@ Benchmark.memory do |x|
   x.report("branch") { Raven.capture_exception(RAILS_EXC) }
 
   x.compare!
-  x.hold!("allocation_comparison.json")
+  x.hold!("/tmp/allocation_comparison.json")
 end
 


### PR DESCRIPTION
This job will automatically compare memory allocation between the master branch and the current PR's branch.

A sample build: https://github.com/getsentry/raven-ruby/runs/1008303905?check_suite_focus=true

Sample result:

```
Calculating -------------------------------------
              branch   421.958k memsize (     9.282k retained)
                         3.521k objects (    11.000  retained)
                        50.000  strings (     4.000  retained)

Comparison:
              master:     421958 allocated
              branch:     421958 allocated - same
```