### PR TITLE
Add zeus upload workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,9 @@
 name: Test
 
-on: 
+on:
   push:
     branches:
       - master
-      - release/**
   pull_request:
 jobs:
   test:
@@ -47,7 +46,7 @@ jobs:
     - name: Build with Rails ${{ matrix.rails_version }}
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}
-      run: | 
+      run: |
         bundle install --jobs 4 --retry 3
         bundle exec rake
 
@@ -83,31 +82,6 @@ jobs:
     - name: Rebuild on the branch
       run: |
         bundle install --jobs 4 --retry 3
-    - name: Run allocation report on the branch 
+    - name: Run allocation report on the branch
       run: |
         bundle exec ruby benchmarks/allocation_comparison.rb
-
-  job_zeus:
-    name: Zeus
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.6 # Not needed with a .ruby-version file
-      - run: bundle install
-      - name: Install Zeus
-        run: |
-          yarn global add @zeus-ci/cli
-          echo "::add-path::$(yarn global bin)"
-      - name: Upload to Zeus
-        env:
-          ZEUS_API_TOKEN: ${{ secrets.ZEUS_API_TOKEN }}
-          ZEUS_HOOK_BASE: ${{ secrets.ZEUS_HOOK_BASE }}
-        run: |
-          zeus job update -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -r $GITHUB_SHA
-          gem build sentry-raven.gemspec
-          zeus upload -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -t "application/tar+gem" ./*.gem
-          zeus job update --status=passed -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -r $GITHUB_SHA

--- a/.github/workflows/zeus_upload.yml
+++ b/.github/workflows/zeus_upload.yml
@@ -1,0 +1,32 @@
+name: Zeus Upload
+
+on:
+  push:
+    branches:
+      - release/**
+
+jobs:
+  zeus_upload:
+    name: Zeus
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6 # Not needed with a .ruby-version file
+      - run: bundle install
+      - name: Install Zeus
+        run: |
+          yarn global add @zeus-ci/cli
+          echo "::add-path::$(yarn global bin)"
+      - name: Upload to Zeus
+        env:
+          ZEUS_API_TOKEN: ${{ secrets.ZEUS_API_TOKEN }}
+          ZEUS_HOOK_BASE: ${{ secrets.ZEUS_HOOK_BASE }}
+        run: |
+          zeus job update -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -r $GITHUB_SHA
+          gem build sentry-raven.gemspec
+          zeus upload -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -t "application/tar+gem" ./*.gem
+          zeus job update --status=passed -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -r $GITHUB_SHA


### PR DESCRIPTION
Zeus upload only needs to be run when releasing, so this PR moves it to a standalone file with a customized branch trigger. I also have created `release/test` branch to test the new job, here's the [result](https://github.com/getsentry/raven-ruby/runs/1008413896?check_suite_focus=true).