### PR TITLE
Avoid mutating user passed in options

### DIFF
--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -1,4 +1,5 @@
 require 'raven/version'
+require 'raven/core_ext/object/deep_dup'
 require 'raven/backtrace'
 require 'raven/breadcrumbs'
 require 'raven/processor'

--- a/lib/raven/core_ext/object/deep_dup.rb
+++ b/lib/raven/core_ext/object/deep_dup.rb
@@ -1,0 +1,51 @@
+class Object
+  # Returns a deep copy of object if it's duplicable. If it's
+  # not duplicable, returns +self+.
+  #
+  #   object = Object.new
+  #   dup    = object.deep_dup
+  #   dup.instance_variable_set(:@a, 1)
+  #
+  #   object.instance_variable_defined?(:@a) # => false
+  #   dup.instance_variable_defined?(:@a)    # => true
+  def deep_dup
+    duplicable? ? dup : self
+  end
+end
+
+class Array
+  # Returns a deep copy of array.
+  #
+  #   array = [1, [2, 3]]
+  #   dup   = array.deep_dup
+  #   dup[1][2] = 4
+  #
+  #   array[1][2] # => nil
+  #   dup[1][2]   # => 4
+  def deep_dup
+    map(&:deep_dup)
+  end
+end
+
+class Hash
+  # Returns a deep copy of hash.
+  #
+  #   hash = { a: { b: 'b' } }
+  #   dup  = hash.deep_dup
+  #   dup[:a][:c] = 'c'
+  #
+  #   hash[:a][:c] # => nil
+  #   dup[:a][:c]  # => "c"
+  def deep_dup
+    hash = dup
+    each_pair do |key, value|
+      if key.frozen? && ::String === key
+        hash[key] = value.deep_dup
+      else
+        hash.delete(key)
+        hash[key.deep_dup] = value.deep_dup
+      end
+    end
+    hash
+  end
+end

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -110,6 +110,7 @@ module Raven
       end
 
       message_or_exc = obj.is_a?(String) ? "message" : "exception"
+      options = options.deep_dup
       options[:configuration] = configuration
       options[:context] = context
       if evt = Event.send("from_" + message_or_exc, obj, options)

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -434,6 +434,14 @@ RSpec.describe Raven::Event do
         expect(Raven::Event.capture_message(message)).to be_a(Raven::Event)
       end
 
+      it "doesn't change the option hash" do
+        h_int = {abc: :abc}
+        h = {k1: h_int, k2: h_int}
+        Raven.capture_message "Test extra", extra: {h1: h, h2: h_int}
+
+        expect(h).to eq({k1: h_int, k2: h_int})
+      end
+
       it "sets the message to the value passed" do
         expect(hash[:message]).to eq(message)
       end


### PR DESCRIPTION
This fixes #924 and #903

Here's an issue demonstration borrowed from #924 

```ruby
h_int = {abc: :abc}
=> {:abc=>:abc}
h = {k1: h_int, k2: h_int}
=> {:k1=>{:abc=>:abc}, :k2=>{:abc=>:abc}}
Raven.capture_message "Test extra", extra: {h1: h, h2: h_int}

h
=> {:k1=>{:abc=>:abc}, :k2=>"(...)"}
```

There are 2 factors that cause the issue:
1. User-provided options will be embedded as part of the `Event` object.
2. When we encode the `Event` object, processors like `RemoveCircularReferences` use mutation methods like `Hash#merge!` to save memory allocation.

### First Attempt - Drop methods that mutate the data

A quick fix is to change the step `2` to just use methods like `Hash#merge`. But this can have a significant impact on the memory allocation (about 16~17% more) per `Raven#capture_message` call. 

Here's an example:

**Code Change**

```
# lib/raven/processor/removecircularreferences.rb
       case value
       when Hash
         - !value.frozen? ? value.merge!(value) { |_, v| process v, visited } : value.merge(value) { |_, v| process v, visited }
         + value.merge(value) { |_, v| process v, visited }
       when Array
         - !value.frozen? ? value.map! { |v| process v, visited } : value.map { |v| process v, visited }
         + value.map { |v| process v, visited }
       else
         value
       end
```

**Allocation before the change**

```
Calculating -------------------------------------
              master   448.434k memsize (    17.474k retained)
                         3.632k objects (    11.000  retained)
                        50.000  strings (     4.000  retained)
```

**Allocation after the change + comparsion**

```
Calculating -------------------------------------
              branch   519.698k memsize (    17.474k retained)
                         3.838k objects (    11.000  retained)
                        50.000  strings (     4.000  retained)
```

**Allocation Comparison**

```
Comparison:
              master:     448434 allocated
              branch:     519698 allocated - 1.16x more
```

### A More Allocation-Efficient Solution - Duplicate user-passed data (options)

By duplicating user-passed objects, we can avoid the later mutations from changing the data user has. And because user-passed data usually won't be too big, we won't allocate too much memory by doing this. Here's an example:


**Code Change**

```
# lib/raven/instance.rb
   def capture_type(obj, options = {})
      # .....
      message_or_exc = obj.is_a?(String) ? "message" : "exception"
      + options = options.deep_dup
      options[:configuration] = configuration
      # .....
```

**Allocation before the change**

```
Calculating -------------------------------------
              master   448.434k memsize (    17.474k retained)
                         3.632k objects (    11.000  retained)
                        50.000  strings (     4.000  retained)
```

**Allocation after the change**

```
Calculating -------------------------------------
              branch   448.666k memsize (    17.474k retained)
                         3.633k objects (    11.000  retained)
                        50.000  strings (     4.000  retained)
```

**Allocation Comparison**

```
Comparison:
              master:     448434 allocated
              branch:     448666 allocated - 1.00x more
```

As you can see, this approach only allocates about 2xx bytes more of memory. So it's the approach I chose in this PR.

### Question - Why making our own `deep_dup` extension instead of using `ActiveSupport`'s?

1. It's not worth adding a new dependency just for one of its files. This could greatly impact the size of some non-rails apps.
2. The [implementation](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/deep_dup.rb) of `deep_dup` is very stable and hasn't changed for 3 years. So it's not a great risk that we'll be out-of-sync on it.
