### PR TITLE
Don't log warning messages when it doesn't need to

### DIFF
--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -342,6 +342,10 @@ module Raven
       end
     end
 
+    def enabled_in_current_env?
+      environments.empty? || environments.include?(current_environment)
+    end
+
     private
 
     def detect_project_root
@@ -423,7 +427,7 @@ module Raven
     end
 
     def capture_in_current_environment?
-      return true unless environments.any? && !environments.include?(current_environment)
+      return true if enabled_in_current_env?
 
       @errors << "Not configured to send/capture in environment '#{current_environment}'"
       false

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -50,6 +50,7 @@ module Raven
 
     # Tell the log that the client is good to go
     def report_status
+      return unless configuration.enabled_in_current_env?
       return if configuration.silence_ready
 
       if configuration.capture_allowed?


### PR DESCRIPTION
This SDK can be enabled by the environments config. So when it's not enabled in the current environment, it shouldn't log any messages.

Closes #915 