### PR TITLE
Revert "Refactor Client class #995"

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -136,25 +136,6 @@ module Raven
       JSON.parse(JSON.generate(cleaned_hash))
     end
 
-    def message_from_exception
-      exception = @interfaces[:exception]
-
-      return unless exception
-
-      exception = exception.to_hash
-
-      type = exception.dig(:values, 0, :type)
-      value = exception.dig(:values, 0, :value)
-
-      if type && value
-        "#{type}: #{value}"
-      end
-    end
-
-    def log_message
-      message || message_from_exception
-    end
-
     def add_exception_interface(exc)
       interface(:exception) do |exc_int|
         exceptions = Raven::Utils::ExceptionCauseChain.exception_to_array(exc).reverse

--- a/spec/raven/client_spec.rb
+++ b/spec/raven/client_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe Raven::Client do
     )
   end
 
+  it "generates a message with exception" do
+    event = Raven::Event.capture_exception(ZeroDivisionError.new("divided by 0")).to_hash
+    expect(client.send(:get_message_from_exception, event)).to eq("ZeroDivisionError: divided by 0")
+  end
+
+  it "generates a message without exception" do
+    event = Raven::Event.from_message("this is an STDOUT transport test").to_hash
+    expect(client.send(:get_message_from_exception, event)).to eq(nil)
+  end
+
   it "generates an auth header without a secret (Sentry 9)" do
     client.configuration.server = "https://66260460f09b5940498e24bb7ce093a0@sentry.io/42"
 

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -720,16 +720,4 @@ RSpec.describe Raven::Event do
       expect(Raven::Event.capture_exception(exception, :logger => 'root').logger).to eq('root')
     end
   end
-
-  describe "#message_from_exception" do
-    it "generates a message with exception" do
-      event = Raven::Event.capture_exception(ZeroDivisionError.new("divided by 0"))
-      expect(event.message_from_exception).to eq("ZeroDivisionError: divided by 0")
-    end
-
-    it "generates a message without exception" do
-      event = Raven::Event.from_message("this is an STDOUT transport test")
-      expect(event.message_from_exception).to eq(nil)
-    end
-  end
 end

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -48,18 +48,12 @@ RSpec.describe "Integration tests" do
     expect(@io.string).to match(/Failed to submit event: ZeroDivisionError: divided by 0$/)
   end
 
-  it "transport failure should call transport_failure_callback and yield even hash" do
-    event = nil
-    @instance.configuration.transport_failure_callback = proc do |e|
-      event = e
-      @io.puts "OK!"
-    end
+  it "transport failure should call transport_failure_callback" do
+    @instance.configuration.transport_failure_callback = proc { |_e| @io.puts "OK!" }
 
     expect(@instance.client.transport).to receive(:send_event).exactly(1).times.and_raise(Faraday::ConnectionFailed, "conn failed")
     @instance.capture_exception(build_exception)
-
     expect(@io.string).to match(/OK!$/)
-    expect(event).to be_a(Hash)
   end
 
   describe '#before_send' do


### PR DESCRIPTION
The refactoring doesn't work because we don't always send an event with an `Event` object. When sending an event with background processors, we need to convert it into a Ruby hash. And this will break the OO approach I took in the refactoring PR.

This PR also adds some specs to increase test coverage on `Client#send_event`.

Closes #1001 