### PR TITLE
[v3 Branch Pick] Add some error context in transport_failure_callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ end
 If Raven fails to send an event to Sentry for any reason (either the Sentry server has returned a 4XX or 5XX response), this Proc or lambda will be called.
 
 ```ruby
-config.transport_failure_callback = lambda { |event|
-  AdminMailer.email_admins("Oh god, it's on fire!", event).deliver_later
+config.transport_failure_callback = lambda { |event, error|
+  AdminMailer.email_admins("Oh god, it's on fire because #{error.message}!", event).deliver_later
 }
 ```
 

--- a/lib/raven/client.rb
+++ b/lib/raven/client.rb
@@ -125,7 +125,7 @@ module Raven
       configuration.logger.warn("Failed to submit event: #{get_log_message(event)}")
 
       # configuration.transport_failure_callback can be false & nil
-      configuration.transport_failure_callback.call(event) if configuration.transport_failure_callback # rubocop:disable Style/SafeNavigation
+      configuration.transport_failure_callback.call(event, e) if configuration.transport_failure_callback # rubocop:disable Style/SafeNavigation
     end
   end
 

--- a/spec/raven/integration_spec.rb
+++ b/spec/raven/integration_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe "Integration tests" do
   end
 
   it "transport failure should call transport_failure_callback" do
-    @instance.configuration.transport_failure_callback = proc { |_e| @io.puts "OK!" }
+    @instance.configuration.transport_failure_callback = proc { |_event, error| @io.puts "OK! - #{error.message}" }
 
     expect(@instance.client.transport).to receive(:send_event).exactly(1).times.and_raise(Faraday::ConnectionFailed, "conn failed")
     @instance.capture_exception(build_exception)
-    expect(@io.string).to match(/OK!$/)
+    expect(@io.string).to match(/OK! - conn failed$/)
   end
 
   describe '#before_send' do


### PR DESCRIPTION
This picks the changes from https://github.com/getsentry/raven-ruby/pull/796 with some additional fixes.

Closes #661 