### PR TITLE
Accept non-string message in Event.from_exception

### DIFF
--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -81,7 +81,17 @@ module Raven
     end
 
     def message=(args)
-      message, params = *args
+      if args.is_a?(Array)
+        message, params = args[0], args[0..-1]
+      else
+        message = args
+      end
+
+      unless message.is_a?(String)
+        Raven.configuration.logger.debug("You're passing a non-string message")
+        message = message.to_s
+      end
+
       interface(:message) do |int|
         int.message = message.byteslice(0...MAX_MESSAGE_SIZE_IN_BYTES) # Messages limited to 10kb
         int.params = params

--- a/spec/raven/event_spec.rb
+++ b/spec/raven/event_spec.rb
@@ -366,6 +366,25 @@ RSpec.describe Raven::Event do
     end
   end
 
+  describe ".from_exception" do
+    it "proceses string message correctly" do
+      event = Raven::Event.from_exception(ExceptionWithContext.new, message: "MSG")
+      expect(event.message).to eq("MSG")
+    end
+
+    it "slices long string message" do
+      event = Raven::Event.from_exception(ExceptionWithContext.new, message: "MSG" * 3000)
+      expect(event.message.length).to eq(8192)
+    end
+
+    it "converts non-string message into string" do
+      expect(Raven.configuration.logger).to receive(:debug).with("You're passing a non-string message")
+
+      event = Raven::Event.from_exception(ExceptionWithContext.new, message: { foo: "bar" })
+      expect(event.message).to eq("{:foo=>\"bar\"}")
+    end
+  end
+
   describe '.to_json_compatible' do
     subject do
       Raven::Event.new(:extra => {


### PR DESCRIPTION
As an error-reporting SDK, it shouldn't fail just because the user passed a non-string message. We should force-convert the input into a string and notify the user about it.

Closes #907 