### PR TITLE
Fix merge error from rack-timeout raven_context on old releases

### DIFF
--- a/lib/raven/integrations/rack-timeout.rb
+++ b/lib/raven/integrations/rack-timeout.rb
@@ -10,7 +10,11 @@ module RackTimeoutExtensions
     # Only rack-timeout 0.3.0+ provides the request environment, but we can't
     # gate this based on a gem version constant because rack-timeout does
     # not provide one.
-    { :fingerprint => ["{{ default }}", env["REQUEST_URI"]] } if defined?(env)
+    if defined?(env)
+      { :fingerprint => ["{{ default }}", env["REQUEST_URI"]] }
+    else
+      {}
+    end
   end
 end
 

--- a/spec/raven/integrations/rack_timeout_spec.rb
+++ b/spec/raven/integrations/rack_timeout_spec.rb
@@ -8,4 +8,11 @@ RSpec.describe "Rack timeout" do
 
     expect(exc.raven_context[:fingerprint]).to eq(["{{ default }}", "This is a URI"])
   end
+
+  it "should return an empty context if env is missing" do
+    exception = Object.new
+    exception.extend(RackTimeoutExtensions)
+
+    expect(exception.raven_context).to eq({})
+  end
 end


### PR DESCRIPTION
Originally nils returned from raven_context were permitted, but with the
refactor from #741 this gets passed directly to merge and raises an
error. Switch to returning an empty hash rather than nil on old
rack-timeout releases which don't have "env" set to avoid this problem.