### PR TITLE
Support cleaning up exception backtrace with customized backtrace_cleaner

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,9 @@ Style/CommentedKeyword:
 Style/RescueModifier:
   Enabled: false
 
+Style/RegexpLiteral:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: false
 

--- a/lib/raven/backtrace.rb
+++ b/lib/raven/backtrace.rb
@@ -94,6 +94,8 @@ module Raven
     def self.parse(backtrace, opts = {})
       ruby_lines = backtrace.is_a?(Array) ? backtrace : backtrace.split(/\n\s*/)
 
+      ruby_lines = opts[:configuration].backtrace_cleanup_callback.call(ruby_lines) if opts[:configuration]&.backtrace_cleanup_callback
+
       filters = opts[:filters] || []
       filtered_lines = ruby_lines.to_a.map do |line|
         filters.reduce(line) do |nested_line, proc|

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -118,6 +118,19 @@ module Raven
     # Otherwise, can be one of "http", "https", or "dummy"
     attr_accessor :scheme
 
+    # a proc/lambda that takes an array of stack traces
+    # it'll be used to silence (reduce) backtrace of the exception
+    #
+    # for example:
+    #
+    # ```ruby
+    # Raven.configuration.backtrace_cleanup_callback = lambda do |backtrace|
+    #   Rails.backtrace_cleaner.clean(backtrace)
+    # end
+    # ```
+    #
+    attr_accessor :backtrace_cleanup_callback
+
     # Secret key for authentication with the Sentry server
     # If you provide a DSN, this will be set automatically.
     #

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -175,7 +175,7 @@ module Raven
     end
 
     def stacktrace_interface_from(backtrace)
-      Backtrace.parse(backtrace).lines.reverse.each_with_object([]) do |line, memo|
+      Backtrace.parse(backtrace, { configuration: configuration }).lines.reverse.each_with_object([]) do |line, memo|
         frame = StacktraceInterface::Frame.new
         frame.abs_path = line.file if line.file
         frame.function = line.method if line.method

--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -5,6 +5,7 @@ module Raven
     require 'raven/integrations/rails/overrides/streaming_reporter'
     require 'raven/integrations/rails/controller_methods'
     require 'raven/integrations/rails/controller_transaction'
+    require 'raven/integrations/rails/backtrace_cleaner'
     require 'raven/integrations/rack'
 
     initializer "raven.use_rack_middleware" do |app|
@@ -37,6 +38,12 @@ module Raven
 
     config.before_initialize do
       Raven.configuration.logger = ::Rails.logger
+
+      backtrace_cleaner = Raven::Rails::BacktraceCleaner.new
+
+      Raven.configuration.backtrace_cleanup_callback = lambda do |backtrace|
+        backtrace_cleaner.clean(backtrace)
+      end
     end
 
     config.after_initialize do

--- a/lib/raven/integrations/rails/backtrace_cleaner.rb
+++ b/lib/raven/integrations/rails/backtrace_cleaner.rb
@@ -1,0 +1,29 @@
+require "active_support/backtrace_cleaner"
+require "active_support/core_ext/string/access"
+
+module Raven
+  class Rails
+    class BacktraceCleaner < ActiveSupport::BacktraceCleaner
+      APP_DIRS_PATTERN = /\A(?:\.\/)?(?:app|config|lib|test|\(\w*\))/.freeze
+      RENDER_TEMPLATE_PATTERN = /:in `.*_\w+_{2,3}\d+_\d+'/.freeze
+
+      def initialize
+        super
+        # we don't want any default silencers because they're too aggressive
+        remove_silencers!
+
+        @root = "#{Raven.configuration.project_root}/"
+        add_filter do |line|
+          line.start_with?(@root) ? line.from(@root.size) : line
+        end
+        add_filter do |line|
+          if line =~ RENDER_TEMPLATE_PATTERN
+            line.sub(RENDER_TEMPLATE_PATTERN, "")
+          else
+            line
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/raven/backtrace_spec.rb
+++ b/spec/raven/backtrace_spec.rb
@@ -5,6 +5,19 @@ RSpec.describe Raven::Backtrace do
     @backtrace = Raven::Backtrace.parse(Thread.current.backtrace)
   end
 
+  it "calls backtrace_cleanup_callback if it's present in the configuration" do
+    called = false
+    callback = proc do |backtrace|
+      called = true
+      backtrace
+    end
+    config = Raven.configuration
+    config.backtrace_cleanup_callback = callback
+    Raven::Backtrace.parse(Thread.current.backtrace, configuration: config)
+
+    expect(called).to eq(true)
+  end
+
   it "#lines" do
     expect(@backtrace.lines.first).to be_a(Raven::Backtrace::Line)
   end

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -254,6 +254,18 @@ RSpec.describe Raven::Configuration do
     end
   end
 
+  describe "config: backtrace_cleanup_callback" do
+    it "defaults to nil" do
+      expect(subject.backtrace_cleanup_callback).to eq(nil)
+    end
+
+    it "takes a proc and store it" do
+      subject.backtrace_cleanup_callback = proc {}
+
+      expect(subject.backtrace_cleanup_callback).to be_a(Proc)
+    end
+  end
+
   context 'with a should_capture callback configured' do
     before(:each) do
       subject.should_capture = ->(exc_or_msg) { exc_or_msg != "dont send me" }

--- a/spec/support/test_rails_app/app.rb
+++ b/spec/support/test_rails_app/app.rb
@@ -21,6 +21,7 @@ class TestApp < Rails::Application
 
   routes.append do
     get "/exception", :to => "hello#exception"
+    get "/view_exception", :to => "hello#view_exception"
     root :to => "hello#world"
   end
 
@@ -34,6 +35,10 @@ end
 class HelloController < ActionController::Base
   def exception
     raise "An unhandled exception!"
+  end
+
+  def view_exception
+    render inline: "<%= foo %>"
   end
 
   def world


### PR DESCRIPTION
This PR adds 2 new features:


## New config option: `backtrace_cleanup_callback`
It takes a lambda/proc object (default is `nil`) and will be called with exception's backtrace. Here's an example usage:

```ruby
Raven.configure do |config|
  config.backtrace_cleanup_callback = lambda do |backtrace|
    Rails.backtrace_cleaner.clean(backtrace)
  end
end
```

## Automatically clean Rails app's backtrace

With the Rails integration, it'll automatically use a customized `Raven::Rails::BacktraceCleaner` to clean up exception's backtrace. This can be disabled by:

```ruby
Raven.configure do |config|
  config.backtrace_cleanup_callback = nil
end
```

### Raven::Rails::BacktraceCleaner

This cleaner is pretty much like Rails 6's [backtrace cleaner](https://github.com/rails/rails/blob/master/railties/lib/rails/backtrace_cleaner.rb) but without silencers. The main reason to add this cleaner is to remove template methods from the trace, e.g.

```
app/views/welcome/view_error.html.erb in _app_views_welcome_view_error_html_erb__2807287320172182514_65600 at line 1
```

will become

```
app/views/welcome/view_error.html.erb at line 1
```

This can help Sentry group issues more accurately. See  #957  for more information about this.

Closes #957 