### PR TITLE
Add tests on our breadcrumbs integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 coverage
 pkg
+tmp
 ruby/
 log/
 .bundle

--- a/benchmarks/allocation_comparison.rb
+++ b/benchmarks/allocation_comparison.rb
@@ -13,8 +13,7 @@ Raven.configure do |config|
   config.dsn = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
 end
 
-TestApp.initialize!
-@app = Rack::MockRequest.new(TestApp)
+@app = make_basic_app
 RAILS_EXC = begin
   @app.get("/exception")
 rescue => exc

--- a/benchmarks/allocation_report.rb
+++ b/benchmarks/allocation_report.rb
@@ -15,8 +15,7 @@ Raven.configure do |config|
   config.dsn = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
 end
 
-TestApp.initialize!
-@app = Rack::MockRequest.new(TestApp)
+@app = make_basic_app
 RAILS_EXC = begin
   @app.get("/exception")
 rescue => exc

--- a/benchmarks/async_benchmark.rb
+++ b/benchmarks/async_benchmark.rb
@@ -23,8 +23,7 @@ Raven.configure do |config|
   config.async = ->(event) { event.to_hash } # Simulate throwing this into a Sidekiq job, etc
 end
 
-TestApp.initialize!
-@app = Rack::MockRequest.new(TestApp)
+@app = make_basic_app
 RAILS_EXC = begin
   @app.get("/exception")
 rescue => exc

--- a/benchmarks/benchmark.rb
+++ b/benchmarks/benchmark.rb
@@ -22,8 +22,7 @@ Raven.configure do |config|
   config.dsn = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
 end
 
-TestApp.initialize!
-@app = Rack::MockRequest.new(TestApp)
+@app = make_basic_app
 RAILS_EXC = begin
   @app.get("/exception")
 rescue => exc

--- a/benchmarks/benchmark.yml
+++ b/benchmarks/benchmark.yml
@@ -24,8 +24,7 @@ prelude: |
     config.dsn = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
   end
 
-  TestApp.initialize!
-  @app = Rack::MockRequest.new(TestApp)
+  @app = make_basic_app
   RAILS_EXC = begin
     @app.get("/exception")
   rescue => exc

--- a/benchmarks/profile.rb
+++ b/benchmarks/profile.rb
@@ -13,8 +13,7 @@ Raven.configure do |config|
   config.dsn = "dummy://12345:67890@sentry.localdomain:3000/sentry/42"
 end
 
-TestApp.initialize!
-@app = Rack::MockRequest.new(TestApp)
+@app = make_basic_app
 RAILS_EXC = begin
   @app.get("/exception")
 rescue => exc

--- a/examples/rails-6.0/config/application.rb
+++ b/examples/rails-6.0/config/application.rb
@@ -20,11 +20,11 @@ module Rails60
     # https://github.com/getsentry/raven-ruby/issues/494
     config.exceptions_app = self.routes
 
-    config.rails_activesupport_breadcrumbs = true
     # Inject Sentry logger breadcrumbs
     require 'raven/breadcrumbs/logger'
 
     Raven.configure do |config|
+      config.rails_activesupport_breadcrumbs = true
       config.dsn = 'https://6bca098db7ef423ab983e26e27255fe8:650b2fcf94f942fe9093f656b809a94e@app.getsentry.com/3825'
     end
   end

--- a/lib/raven/breadcrumbs/activesupport.rb
+++ b/lib/raven/breadcrumbs/activesupport.rb
@@ -10,9 +10,13 @@ module Raven
       end
 
       def inject
-        ActiveSupport::Notifications.subscribe(/.*/) do |name, started, finished, unique_id, data|
+        @subscriber = ActiveSupport::Notifications.subscribe(/.*/) do |name, started, finished, unique_id, data|
           add(name, started, finished, unique_id, data)
         end
+      end
+
+      def detach
+        ActiveSupport::Notifications.unsubscribe(@subscriber)
       end
     end
   end

--- a/spec/raven/breadcrumbs/active_support_breadcrumbs_spec.rb
+++ b/spec/raven/breadcrumbs/active_support_breadcrumbs_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+RSpec.describe "Raven::ActiveSupportBreadcrumbs", :type => :request, :rails => true do
+  before(:all) do
+    Raven.configuration.rails_activesupport_breadcrumbs = true
+    Rails.application = make_basic_app
+  end
+
+  after(:all) do
+    Raven.configuration.rails_activesupport_breadcrumbs = false
+    Raven::ActiveSupportBreadcrumbs.detach
+    # even though we cleanup breadcrumbs in the rack middleware
+    # ActiveSupportBreadcrumbs subscribes to "every" instrumentation
+    # so it'll create other instrumentations "after" the request is finished
+    # and we should clear those as well
+    Raven::BreadcrumbBuffer.clear!
+  end
+
+  it "captures correct data" do
+    get "/exception"
+
+    expect(response.status).to eq(500)
+    event = JSON.parse!(Raven.client.transport.events.first[1])
+    breadcrumbs = event.dig("breadcrumbs", "values")
+    expect(breadcrumbs.count).to eq(2)
+
+    if Rails.version.to_i >= 5
+      expect(breadcrumbs.first["data"]).to match(
+        {
+          "controller" => "HelloController",
+          "action" => "exception",
+          "params" => { "controller" => "hello", "action" => "exception" },
+          "headers" => anything,
+          "format" => "html",
+          "method" => "GET",
+          "path" => "/exception"
+        }
+      )
+    else
+      expect(breadcrumbs.first["data"]).to match(
+        {
+          "controller" => "HelloController",
+          "action" => "exception",
+          "params" => { "controller" => "hello", "action" => "exception" },
+          "format" => "html",
+          "method" => "GET",
+          "path" => "/exception"
+        }
+      )
+
+    end
+  end
+end

--- a/spec/raven/breadcrumbs/breadcrumb_logger_spec.rb
+++ b/spec/raven/breadcrumbs/breadcrumb_logger_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+RSpec.describe "Raven::BreadcrumbLogger", :type => :request, :rails => true do
+  before(:all) do
+    require "raven/breadcrumbs/logger"
+    Rails.application = make_basic_app
+  end
+
+  after(:all) do
+    # revert the injected methods to keep other specs clean
+    Raven::BreadcrumbLogger.module_eval do
+      def add(*args)
+        super
+      end
+    end
+  end
+
+  it "captures correct data" do
+    get "/exception"
+
+    expect(response.status).to eq(500)
+    event = JSON.parse!(Raven.client.transport.events.first[1])
+    breadcrumbs = event.dig("breadcrumbs", "values")
+    expect(breadcrumbs.count).to eq(1)
+    expect(breadcrumbs.first).to match(
+      {
+        "category" => "Processing by HelloController#exception as HTML",
+        "data" => {},
+        "level" => "info",
+        "message" => "Processing by HelloController#exception as HTML",
+        "timestamp" => anything,
+        "type" => nil
+      }
+    )
+  end
+end

--- a/spec/raven/integrations/rails_spec.rb
+++ b/spec/raven/integrations/rails_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Rails Integration", :type => :request, :rails => true do
   before(:all) do
-    TestApp.initialize!
+    make_basic_app
   end
 
   after(:each) do
@@ -10,7 +10,7 @@ RSpec.describe "Rails Integration", :type => :request, :rails => true do
   end
 
   it "inserts middleware" do
-    expect(TestApp.middleware).to include(Raven::Rack)
+    expect(Rails.application.middleware).to include(Raven::Rack)
   end
 
   it "doesn't do anything on a normal route" do

--- a/spec/support/test_rails_app/app.rb
+++ b/spec/support/test_rails_app/app.rb
@@ -12,24 +12,6 @@ require 'raven/integrations/rails'
 ActiveSupport::Deprecation.silenced = true
 
 class TestApp < Rails::Application
-  config.secret_key_base = "test"
-
-  # Usually set for us in production.rb
-  config.eager_load = true
-
-  config.hosts = nil
-
-  routes.append do
-    get "/exception", :to => "hello#exception"
-    get "/view_exception", :to => "hello#view_exception"
-    root :to => "hello#world"
-  end
-
-  initializer :configure_release do
-    Raven.configure do |config|
-      config.release = 'beta'
-    end
-  end
 end
 
 class HelloController < ActionController::Base
@@ -44,4 +26,34 @@ class HelloController < ActionController::Base
   def world
     render :plain => "Hello World!"
   end
+end
+
+def make_basic_app
+  app = Class.new(TestApp) do
+    def self.name
+      "RailsTestApp"
+    end
+  end
+
+  app.config.hosts = nil
+  app.config.secret_key_base = "test"
+
+  # Usually set for us in production.rb
+  app.config.eager_load = true
+  app.routes.append do
+    get "/exception", :to => "hello#exception"
+    get "/view_exception", :to => "hello#view_exception"
+    root :to => "hello#world"
+  end
+
+  app.initializer :configure_release do
+    Raven.configure do |config|
+      config.release = 'beta'
+    end
+  end
+
+  app.initialize!
+
+  Rails.application = app
+  app
 end


### PR DESCRIPTION
Breadcrumbs support is one of the SDK's key features. But it's not well-tested, and that'll make sure changes very risky. So this PR adds integration tests for different types of breadcrumbs integrations.

This PR also changes the way we initialize test apps to provide better isolation between integration test cases.