### PR TITLE
Remove BreadcrumbLogger's unused error handling

### DIFF
--- a/spec/raven/breadcrumbs/breadcrumb_logger_spec.rb
+++ b/spec/raven/breadcrumbs/breadcrumb_logger_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Raven::BreadcrumbLogger", :type => :request, :rails => true do
         "level" => "info",
         "message" => "Processing by HelloController#exception as HTML",
         "timestamp" => anything,
-        "type" => nil
+        "type" => "info"
       }
     )
   end


### PR DESCRIPTION
Related PR: https://github.com/getsentry/raven-ruby/pull/497

There are 2 reasons behind this decision:

1. The condition is very rarely, if not never, used.
2. It doesn't provide too much benefit

### The condition is rarely used

We can observe this from 2 places:
- we have quite intensive integration tests, but it's never called
  during tests. See the coverage report [here](https://codecov.io/gh/getsentry/raven-ruby/src/8359014569cee643698ce2e6aebe148dad392d3e/lib/raven/breadcrumbs/logger.rb) 
- the regex it uses to spot the exception doesn't match current
  exceptions anymore:

```ruby
regex = /^([a-zA-Z0-9]+)\:\s(.*)$/

message_from_rails_4_2_error = "ZeroDivisionError (divided by 0):\n  lib/raven/integrations/rails/controller_transaction.rb:7:in `block in included'\n  lib/raven/integrations/rack.rb:51:in `call'"

message_from_rails_5_2_error = "ZeroDivisionError (divided by 0):"

regex.match?(message_from_rails_4_2_error) #=> false
regex.match?(message_from_rails_5_2_error) #=> false
```

And no matter how I try it, I can't enter this condition at all. I've
tried triggering it with tests, test application, and even my other
Rails applications. And I still can't find any message that can match
the exception regex and enter the error handling condition.

I guess it's due to Rails or Ruby versions have been upgraded and now behave differently since then.

### It doesn't provide much benefit

That piece of code handles exception message differently by:

1. assigning a "error" type to it, instead of leave it empty (which is "default")
2. add specially extracted exception type/value to "data" instead of
   "message".

The point 1 is necessary but can easily be done by a little tweak in the
normal recording condition. And the point 2 is not really necessary IMO.
Because according to the [Breadcrumbs Document](https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/), Sentry doesn't handle
error breadcrumb's data differently and the example just uses "message".

### Conclusion

So for the above reasons, I don't think the necessity of this block of
code is very high. And consider that we have many upcoming feature
changes, I think it's better to remove this unreachable code so we can
have 1 less thing to worry about.

(btw, this PR actually makes the breadcrumbs more diverse now. check the screenshots below)

### Breadcrumbs Before
<img width="1242" alt="截圖 2020-09-05 上午9 39 50" src="https://user-images.githubusercontent.com/5079556/92294145-c090d100-ef5b-11ea-820d-a9d3bcd0ca50.png">

### Breadcrumbs After

<img width="1244" alt="截圖 2020-09-05 上午9 39 08" src="https://user-images.githubusercontent.com/5079556/92294140-b8389600-ef5b-11ea-8a99-49ebf24b201f.png">


