### PR TITLE
Unify breadcrumb loggers activation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/PerceivedComplexity:
   Max: 11
 
 Metrics/MethodLength:
-  Max: 30
+  Max: 40
 
 Style/SymbolArray:
   Enabled: false

--- a/examples/rails-6.0/config/application.rb
+++ b/examples/rails-6.0/config/application.rb
@@ -20,11 +20,8 @@ module Rails60
     # https://github.com/getsentry/raven-ruby/issues/494
     config.exceptions_app = self.routes
 
-    # Inject Sentry logger breadcrumbs
-    require 'raven/breadcrumbs/logger'
-
     Raven.configure do |config|
-      config.rails_activesupport_breadcrumbs = true
+      config.breadcrumbs_logger = [:sentry_logger, :active_support_logger]
       config.dsn = 'https://6bca098db7ef423ab983e26e27255fe8:650b2fcf94f942fe9093f656b809a94e@app.getsentry.com/3825'
     end
   end

--- a/lib/raven/base.rb
+++ b/lib/raven/base.rb
@@ -1,4 +1,5 @@
 require 'raven/version'
+require "raven/helpers/deprecation_helper"
 require 'raven/core_ext/object/deep_dup'
 require 'raven/backtrace'
 require 'raven/breadcrumbs'

--- a/lib/raven/breadcrumbs/logger.rb
+++ b/lib/raven/breadcrumbs/logger.rb
@@ -1,1 +1,3 @@
+DeprecationHelper.deprecate_old_breadcrumbs_configuration(:sentry_logger)
+
 require "raven/breadcrumbs/sentry_logger"

--- a/lib/raven/cli.rb
+++ b/lib/raven/cli.rb
@@ -1,6 +1,6 @@
 module Raven
   class CLI
-    def self.test(dsn = nil, silent = false, config = nil) # rubocop:disable all
+    def self.test(dsn = nil, silent = false, config = nil)
       config ||= Raven.configuration
 
       config.logger = if silent

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -88,7 +88,7 @@ module Raven
     attr_accessor :public_key
 
     # Turns on ActiveSupport breadcrumbs integration
-    attr_accessor :rails_activesupport_breadcrumbs
+    attr_reader :rails_activesupport_breadcrumbs
 
     # Rails catches exceptions in the ActionDispatch::ShowExceptions or
     # ActionDispatch::DebugExceptions middlewares, depending on the environment.
@@ -252,7 +252,8 @@ module Raven
       self.open_timeout = 1
       self.processors = DEFAULT_PROCESSORS.dup
       self.project_root = detect_project_root
-      self.rails_activesupport_breadcrumbs = false
+      @rails_activesupport_breadcrumbs = false
+
       self.rails_report_rescued_exceptions = true
       self.release = detect_release
       self.sample_rate = 1.0
@@ -383,6 +384,11 @@ module Raven
     def project_root=(root_dir)
       @project_root = root_dir
       Backtrace::Line.instance_variable_set(:@in_app_pattern, nil) # blow away cache
+    end
+
+    def rails_activesupport_breadcrumbs=(val)
+      DeprecationHelper.deprecate_old_breadcrumbs_configuration(:active_support_logger)
+      @rails_activesupport_breadcrumbs = val
     end
 
     def exception_class_allowed?(exc)

--- a/lib/raven/helpers/deprecation_helper.rb
+++ b/lib/raven/helpers/deprecation_helper.rb
@@ -2,4 +2,16 @@ module DeprecationHelper
   def self.deprecate_dasherized_filename(correct_filename)
     warn "[Deprecation Warning] Dasherized filename \"#{correct_filename.gsub('_', '-')}\" is deprecated and will be removed in 4.0; use \"#{correct_filename}\" instead" # rubocop:disable Style/LineLength
   end
+
+  def self.deprecate_old_breadcrumbs_configuration(logger)
+    deprecated_usage =
+      if logger == :sentry_logger
+        "require \"raven/breadcrumbs/logger\""
+      else
+        "Raven.configuration.rails_activesupport_breadcrumbs = true"
+      end
+    recommended_usage = "Raven.configuration.breadcrumbs_logger = :#{logger}"
+
+    warn "[Deprecation Warning] The way you enable breadcrumbs logger (#{deprecated_usage}) is deprecated and will be removed in 4.0; use '#{recommended_usage}' instead" # rubocop:disable Style/LineLength
+  end
 end

--- a/lib/raven/integrations/rails.rb
+++ b/lib/raven/integrations/rails.rb
@@ -47,7 +47,9 @@ module Raven
     end
 
     config.after_initialize do
-      if Raven.configuration.rails_activesupport_breadcrumbs
+      if Raven.configuration.breadcrumbs_logger.include?(:active_support_logger) ||
+         Raven.configuration.rails_activesupport_breadcrumbs
+
         require 'raven/breadcrumbs/active_support_logger'
         Raven::Breadcrumbs::ActiveSupportLogger.inject
       end

--- a/spec/raven/breadcrumbs/active_support_breadcrumbs_spec.rb
+++ b/spec/raven/breadcrumbs/active_support_breadcrumbs_spec.rb
@@ -2,12 +2,12 @@ require "spec_helper"
 
 RSpec.describe "Raven::Breadcrumbs::ActiveSupportLogger", :type => :request, :rails => true do
   before(:all) do
-    Raven.configuration.rails_activesupport_breadcrumbs = true
+    Raven.configuration.breadcrumbs_logger = [:active_support_logger]
     Rails.application = make_basic_app
   end
 
   after(:all) do
-    Raven.configuration.rails_activesupport_breadcrumbs = false
+    Raven.configuration.breadcrumbs_logger = []
     Raven::Breadcrumbs::ActiveSupportLogger.detach
     # even though we cleanup breadcrumbs in the rack middleware
     # Breadcrumbs::ActiveSupportLogger subscribes to "every" instrumentation

--- a/spec/raven/breadcrumbs/sentry_logger_spec.rb
+++ b/spec/raven/breadcrumbs/sentry_logger_spec.rb
@@ -2,11 +2,12 @@ require "spec_helper"
 
 RSpec.describe "Raven::Breadcrumbs::SentryLogger", :type => :request, :rails => true do
   before(:all) do
-    require "raven/breadcrumbs/sentry_logger"
+    Raven.configuration.breadcrumbs_logger = [:sentry_logger]
     Rails.application = make_basic_app
   end
 
   after(:all) do
+    Raven.configuration.breadcrumbs_logger = []
     # revert the injected methods to keep other specs clean
     Raven::Breadcrumbs::SentryLogger.module_eval do
       def add(*args)

--- a/spec/raven/configuration_spec.rb
+++ b/spec/raven/configuration_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe Raven::Configuration do
     expect(subject.server).to     eq("http://sentry.localdomain:3000/sentry")
   end
 
+  describe "#breadcrumbs_logger=" do
+    it "raises error when given an invalid option" do
+      expect { subject.breadcrumbs_logger = :foo }.to raise_error(
+        Raven::Error,
+        'Unsupported breadcrumbs logger. Supported loggers: [:sentry_logger, :active_support_logger]'
+      )
+    end
+  end
+
   it "doesnt accept invalid encodings" do
     expect { subject.encoding = "apple" }.to raise_error(Raven::Error, 'Unsupported encoding')
   end


### PR DESCRIPTION
This will replace the way we activate our breadcrumbs loggers.
Currently, we have `SentryLogger` and `ActiveSupportLogger` for
logging breadcrumbs. And they need to be activated differently:

```ruby
require "raven/breadcrumbs/sentry_logger"
Raven.configuration.rails_activesupport_breadcrumbs = true
```

It's not a nice user interface, so this PR adds a new configuration
option `breadcrumbs_logger` to improve this:

```ruby
Raven.configuration.breadcrumbs_logger = :sentry_logger
Raven.configuration.breadcrumbs_logger = :active_support_logger
Raven.configuration.breadcrumbs_logger = [:sentry_logger, :active_support_logger]
```

However, the old activation ways will still be supported until version 4.0 with deprecation warnings.

Closes #665 