### PR TITLE
allow changing the default logger for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - REFACTOR: Refactor event initialization ([#1010](https://github.com/getsentry/raven-ruby/pull/1010))
 - REFACTOR: Unify breadcrumb loggers activation ([#1016](https://github.com/getsentry/raven-ruby/pull/1016))
 - FIX: Fix merge error from rack-timeout raven_context on old releases ([#1007](https://github.com/getsentry/raven-ruby/pull/1007))
+- FEATURE: allow changing the default logger in events
 
 ## 3.0.4
 

--- a/lib/raven/configuration.rb
+++ b/lib/raven/configuration.rb
@@ -168,6 +168,9 @@ module Raven
     # Should the SSL certificate of the server be verified?
     attr_accessor :ssl_verification
 
+    # Default logger for events. String.
+    attr_accessor :default_logger
+
     # Default tags for events. Hash.
     attr_accessor :tags
 
@@ -270,6 +273,7 @@ module Raven
       self.timeout = 2
       self.transport_failure_callback = false
       self.before_send = false
+      self.default_logger = :ruby
     end
 
     def server=(value)

--- a/lib/raven/event.rb
+++ b/lib/raven/event.rb
@@ -25,7 +25,6 @@ module Raven
       self.id            = SecureRandom.uuid.delete("-")
       self.timestamp     = Time.now.utc
       self.level         = :error
-      self.logger        = :ruby
       self.platform      = :ruby
       self.sdk           = SDK
 
@@ -207,6 +206,7 @@ module Raven
       self.release     ||= configuration.release
       self.modules       = list_gem_specs if configuration.send_modules
       self.environment ||= configuration.current_environment
+      self.logger      ||= configuration.default_logger
     end
 
     def set_core_attributes_from_context


### PR DESCRIPTION
Can't use `logger` as that key is already in use.