### PR TITLE
Allow blocks on user_context

### DIFF
--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -176,7 +176,12 @@ module Raven
     # @example
     #   Raven.user_context('id' => 1, 'email' => 'foo@example.com')
     def user_context(options = nil)
+      original_user_context = context.user
       context.user = options || {}
+      yield if block_given?
+      context.user
+    ensure
+      context.user = original_user_context
     end
 
     # Bind tags context. Merges with existing context (if any).

--- a/lib/raven/instance.rb
+++ b/lib/raven/instance.rb
@@ -181,7 +181,7 @@ module Raven
       yield if block_given?
       context.user
     ensure
-      context.user = original_user_context
+      context.user = original_user_context if block_given?
     end
 
     # Bind tags context. Merges with existing context (if any).

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -247,9 +247,19 @@ RSpec.describe Raven::Instance do
 
   describe "#user_context" do
     context "without a block" do
-      it "empties the user context when called" do
+      it "empties the user context when called without options" do
         subject.context.user = { id: 1 }
         expect(subject.user_context).to eq({})
+      end
+      
+      it "empties the user context when called with nil" do
+        subject.context.user = { id: 1 }
+        expect(subject.user_context(nil)).to eq({})
+      end
+      
+      it "empties the user context when called with {}" do
+        subject.context.user = { id: 1 }
+        expect(subject.user_context({})).to eq({})
       end
 
       it "returns the user context when set" do

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -245,6 +245,20 @@ RSpec.describe Raven::Instance do
     end
   end
 
+  describe "#user_context" do
+    context "without a block" do
+      it "empties the context when called" do
+        subject.context.user = { id: 1 }
+        expect(subject.user_context).to eq({})
+      end
+
+      it "returns the context when set" do
+        expected = { id: 1 }
+        expect(subject.user_context(expected)).to eq(expected)
+      end
+    end
+  end
+
   describe "#tags_context" do
     let(:default) { { :foo => :bar } }
     let(:additional) { { :baz => :qux } }

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -251,12 +251,12 @@ RSpec.describe Raven::Instance do
         subject.context.user = { id: 1 }
         expect(subject.user_context).to eq({})
       end
-      
+
       it "empties the user context when called with nil" do
         subject.context.user = { id: 1 }
         expect(subject.user_context(nil)).to eq({})
       end
-      
+
       it "empties the user context when called with {}" do
         subject.context.user = { id: 1 }
         expect(subject.user_context({})).to eq({})

--- a/spec/raven/instance_spec.rb
+++ b/spec/raven/instance_spec.rb
@@ -247,14 +247,34 @@ RSpec.describe Raven::Instance do
 
   describe "#user_context" do
     context "without a block" do
-      it "empties the context when called" do
+      it "empties the user context when called" do
         subject.context.user = { id: 1 }
         expect(subject.user_context).to eq({})
       end
 
-      it "returns the context when set" do
+      it "returns the user context when set" do
         expected = { id: 1 }
         expect(subject.user_context(expected)).to eq(expected)
+      end
+    end
+
+    context "with a block" do
+      it "returns the user context when set" do
+        expected = { id: 1 }
+        user_context = subject.user_context(expected) do
+          # do nothing
+        end
+        expect(user_context).to eq expected
+      end
+
+      it "sets user context only in the block" do
+        subject.context.user = previous_user_context = { id: 9999 }
+        new_user_context = { id: 1 }
+
+        subject.user_context(new_user_context) do
+          expect(subject.context.user).to eq new_user_context
+        end
+        expect(subject.context.user).to eq previous_user_context
       end
     end
   end


### PR DESCRIPTION
This makes user_context block receivable and it defines a scope for the tags/extra.

Before:

```
Raven.user_context id: user.id
Raven.capture_message("foo")
Raven.user_context
```

After:
```
Raven.user_context id: user.id do
  Raven.capture_message("foo")
end
```

---

I believe I updated this in a way that did not break anyone's expectations of the return value.
*Note* The method documentation for `user_context` says that it `Merges with existing context (if any).` but that is not actually the case, nor have I made it work as documented.