### PR TITLE
Return value of `rescue_with_handler` when intercepting ActiveJob exceptions

### DIFF
--- a/lib/raven/integrations/rails/active_job.rb
+++ b/lib/raven/integrations/rails/active_job.rb
@@ -21,7 +21,8 @@ module Raven
       def capture_and_reraise_with_sentry(job, block)
         block.call
       rescue Exception => e # rubocop:disable Lint/RescueException
-        return if rescue_with_handler(e)
+        rescue_handler_result = rescue_with_handler(e)
+        return rescue_handler_result if rescue_handler_result
 
         Raven.capture_exception(e, :extra => raven_context(job))
         raise e


### PR DESCRIPTION
## Description

When using ActiveJob's `rescue_from` (or `retry_on` / `discard_on` which are implemented with `rescue_from`), ActiveJob will return the captured exception. This PR fixes Sentry's ActiveJob instrumentation to preserve that behavior.